### PR TITLE
24 fix deprecation warnings

### DIFF
--- a/copulas/multivariate/GaussianCopula.py
+++ b/copulas/multivariate/GaussianCopula.py
@@ -62,9 +62,9 @@ class GaussianCopula(MVCopula):
             # get inverse cdf using standard normal
             res.loc[:, col] = st.norm.ppf(cdf)
         n = res.shape[1]
-        means = [np.mean(res.iloc[:, i].as_matrix()) for i in range(n)]
+        means = [np.mean(res.iloc[:, i].values) for i in range(n)]
         cov = res.cov()
-        return (cov.as_matrix(), means, res)
+        return (cov.values, means, res)
 
     def get_pdf(self, X):
         # make cov positive semi-definite

--- a/copulas/multivariate/MVCopula.py
+++ b/copulas/multivariate/MVCopula.py
@@ -1,4 +1,4 @@
-class MVCopula:
+class MVCopula(object):
     """ Abstract class for a multi-variate copula object """
 
     def __init__(self):

--- a/tests/multivariate/test_gaussian_copula.py
+++ b/tests/multivariate/test_gaussian_copula.py
@@ -1,0 +1,24 @@
+import warnings
+from unittest import TestCase
+
+import pandas as pd
+
+from copulas.multivariate.GaussianCopula import GaussianCopula
+
+
+class TestGaussianCopula(TestCase):
+
+    def test_deprecation_warnings(self):
+        """After fitting, Gaussian copula can produce new samples warningless."""
+        # Setup
+        copula = GaussianCopula()
+        data = pd.read_csv('data/iris.data.csv')
+
+        # Run
+        with warnings.catch_warnings(record=True) as warns:
+            copula.fit(data)
+            result = copula.sample(10)
+
+            # Check
+            assert len(warns) == 0
+            assert len(result) == 10


### PR DESCRIPTION
Changed deprecated calls to `pd.DataFrame.to_matrix()` with `pd.DataFrame.values`.
Solves #24 