### PR TITLE
Added seed for random numbers generators

### DIFF
--- a/copulas/bivariate/base.py
+++ b/copulas/bivariate/base.py
@@ -194,14 +194,14 @@ class Bivariate(object):
         if self.tau > 1 or self.tau < -1:
             raise ValueError("The range for correlation measure is [-1,1].")
             
-        s, keys, pos, has_gauss, cached_gaussian = np.random.get_state()
+        s = np.random.get_state()
         
         np.random.seed(random_state)
 
         v = np.random.uniform(0, 1, n_samples)
         c = np.random.uniform(0, 1, n_samples)
         
-        np.random.set_state((s, keys, pos, has_gauss, cached_gaussian))
+        np.random.set_state(s)
 
         u = self.percent_point(c, v)
         return np.column_stack((u, v))

--- a/copulas/bivariate/base.py
+++ b/copulas/bivariate/base.py
@@ -188,6 +188,8 @@ class Bivariate(object):
         Args:
             n_samples: `int`, amount of samples to create.
 
+            seed: `int` or None, the seed for the random numbers generator.
+
         Returns:
             np.ndarray: Array of length `n_samples` with generated data from the model.
         """
@@ -196,7 +198,7 @@ class Bivariate(object):
             
         s = np.random.get_state()
         
-        np.random.seed(random_state)
+        np.random.seed(seed)
 
         v = np.random.uniform(0, 1, n_samples)
         c = np.random.uniform(0, 1, n_samples)

--- a/copulas/bivariate/base.py
+++ b/copulas/bivariate/base.py
@@ -182,7 +182,7 @@ class Bivariate(object):
         """
         raise NotImplementedError
 
-    def sample(self, n_samples):
+    def sample(self, n_samples, seed=None):
         """Generate specified `n_samples` of new data from model. `v~U[0,1],v~C^-1(u|v)`
 
         Args:
@@ -193,9 +193,15 @@ class Bivariate(object):
         """
         if self.tau > 1 or self.tau < -1:
             raise ValueError("The range for correlation measure is [-1,1].")
+            
+        s, keys, pos, has_gauss, cached_gaussian = np.random.get_state()
+        
+        np.random.seed(random_state)
 
         v = np.random.uniform(0, 1, n_samples)
         c = np.random.uniform(0, 1, n_samples)
+        
+        np.random.set_state((s, keys, pos, has_gauss, cached_gaussian))
 
         u = self.percent_point(c, v)
         return np.column_stack((u, v))

--- a/copulas/multivariate/gaussian.py
+++ b/copulas/multivariate/gaussian.py
@@ -194,9 +194,17 @@ class GaussianMultivariate(Multivariate):
         means = np.zeros(self.covariance.shape[0])
         size = (num_rows,)
 
-        # clean up cavariance matrix
+        # clean up covariance matrix
         clean_cov = np.nan_to_num(self.covariance)
+        
+        s, keys, pos, has_gauss, cached_gaussian = np.random.get_state()
+        
+        np.random.seed(random_state)
+        
         samples = np.random.multivariate_normal(means, clean_cov, size=size)
+        
+        np.random.set_state((s, keys, pos, has_gauss, cached_gaussian))
+        
         # run through cdf and inverse cdf
         for i, (label, distrib) in enumerate(self.distribs.items()):
             # use standard normal's cdf
@@ -204,6 +212,7 @@ class GaussianMultivariate(Multivariate):
 
             # use original distributions inverse cdf
             res[label] = distrib.percent_point(res[label])
+            
         return pd.DataFrame(data=res)
 
     def to_dict(self):

--- a/copulas/multivariate/gaussian.py
+++ b/copulas/multivariate/gaussian.py
@@ -197,13 +197,13 @@ class GaussianMultivariate(Multivariate):
         # clean up covariance matrix
         clean_cov = np.nan_to_num(self.covariance)
         
-        s, keys, pos, has_gauss, cached_gaussian = np.random.get_state()
+        s = np.random.get_state()
         
         np.random.seed(random_state)
         
         samples = np.random.multivariate_normal(means, clean_cov, size=size)
         
-        np.random.set_state((s, keys, pos, has_gauss, cached_gaussian))
+        np.random.set_state(s)
         
         # run through cdf and inverse cdf
         for i, (label, distrib) in enumerate(self.distribs.items()):

--- a/copulas/multivariate/gaussian.py
+++ b/copulas/multivariate/gaussian.py
@@ -180,11 +180,13 @@ class GaussianMultivariate(Multivariate):
         ranges = [[lower_bound, val] for val in X]
         return integrate.nquad(func, ranges)[0]
 
-    def sample(self, num_rows=1):
+    def sample(self, num_rows=1, seed=None):
         """Creates sintentic values stadistically similar to the original dataset.
 
         Args:
             num_rows: `int` amount of samples to generate.
+
+            seed: `int` or None, the seed for the random numbers generator.
 
         Returns:
             np.ndarray: Sampled data.
@@ -199,7 +201,7 @@ class GaussianMultivariate(Multivariate):
         
         s = np.random.get_state()
         
-        np.random.seed(random_state)
+        np.random.seed(seed)
         
         samples = np.random.multivariate_normal(means, clean_cov, size=size)
         

--- a/copulas/multivariate/vine.py
+++ b/copulas/multivariate/vine.py
@@ -1,5 +1,6 @@
 import logging
-from random import randint
+# from random import randint, seed, getstate, setstate
+import random
 
 import numpy as np
 from scipy import optimize
@@ -81,11 +82,25 @@ class VineCopula(Multivariate):
 
         return np.sum(values)
 
-    def sample(self, num_rows=1):
+    def sample(self, num_rows=1, seed=None):
         """Generating samples from vine model."""
+        s1 = np.random.get_state()
+        
+        s2 = random.getstate()
+        
+        np.random.seed(seed)
+        
+        random.setstate(seed)
+        
         unis = np.random.uniform(0, 1, self.n_var)
+        
         # randomly select a node to start with
-        first_ind = randint(0, self.n_var - 1)
+        first_ind = random.randint(0, self.n_var - 1)
+        
+        np.random.seed(s1)
+        
+        random.setstate(s2)
+        
         adj = self.trees[0].get_adjacent_matrix()
         visited = []
         explore = [first_ind]

--- a/copulas/univariate/gaussian.py
+++ b/copulas/univariate/gaussian.py
@@ -93,13 +93,13 @@ class GaussianUnivariate(Univariate):
         Returns:
             np.ndarray: Generated samples
         """
-        s, keys, pos, has_gauss, cached_gaussian = np.random.get_state()
+        s = np.random.get_state()
         
         np.random.seed(random_state)
         
         sample = np.random.normal(self.mean, self.std, num_samples)
         
-        np.random.set_state((s, keys, pos, has_gauss, cached_gaussian))
+        np.random.set_state(s)
         
         return sample
 

--- a/copulas/univariate/gaussian.py
+++ b/copulas/univariate/gaussian.py
@@ -82,16 +82,26 @@ class GaussianUnivariate(Univariate):
         """
         return norm.ppf(U, loc=self.mean, scale=self.std)
 
-    def sample(self, num_samples=1):
+    def sample(self, num_samples=1, seed=None):
         """Returns new data point based on model.
 
         Arguments:
             n_samples: `int`
+            
+            seed: `int` or None, the seed for the random numbers generator.
 
         Returns:
             np.ndarray: Generated samples
         """
-        return np.random.normal(self.mean, self.std, num_samples)
+        s, keys, pos, has_gauss, cached_gaussian = np.random.get_state()
+        
+        np.random.seed(random_state)
+        
+        sample = np.random.normal(self.mean, self.std, num_samples)
+        
+        np.random.set_state((s, keys, pos, has_gauss, cached_gaussian))
+        
+        return sample
 
     def to_dict(self):
         return {

--- a/copulas/univariate/gaussian.py
+++ b/copulas/univariate/gaussian.py
@@ -95,7 +95,7 @@ class GaussianUnivariate(Univariate):
         """
         s = np.random.get_state()
         
-        np.random.seed(random_state)
+        np.random.seed(seed)
         
         sample = np.random.normal(self.mean, self.std, num_samples)
         

--- a/copulas/univariate/kde.py
+++ b/copulas/univariate/kde.py
@@ -81,13 +81,13 @@ class KDEUnivariate(Univariate):
         Returns:
             samples: a list of datapoints sampled from the model
         """
-        s, keys, pos, has_gauss, cached_gaussian = np.random.get_state()
+        s = np.random.get_state()
         
         np.random.seed(random_state)
         
         sample = self.model.resample(num_samples)
         
-        np.random.set_state((s, keys, pos, has_gauss, cached_gaussian))
+        np.random.set_state(s)
         
         return sample
 

--- a/copulas/univariate/kde.py
+++ b/copulas/univariate/kde.py
@@ -70,16 +70,26 @@ class KDEUnivariate(Univariate):
 
         return scipy.optimize.brentq(self.cumulative_distribution, -1000.0, 1000.0, args=(U))
 
-    def sample(self, num_samples=1):
+    def sample(self, num_samples=1, seed=None):
         """Samples new data point based on model.
 
         Args:
             num_samples: `int` number of points to be sampled
+            
+            seed: `int` or None, the seed for the random numbers generator.
 
         Returns:
             samples: a list of datapoints sampled from the model
         """
-        return self.model.resample(num_samples)
+        s, keys, pos, has_gauss, cached_gaussian = np.random.get_state()
+        
+        np.random.seed(random_state)
+        
+        sample = self.model.resample(num_samples)
+        
+        np.random.set_state((s, keys, pos, has_gauss, cached_gaussian))
+        
+        return sample
 
     @classmethod
     def from_dict(cls, copula_dict):

--- a/copulas/univariate/kde.py
+++ b/copulas/univariate/kde.py
@@ -83,7 +83,7 @@ class KDEUnivariate(Univariate):
         """
         s = np.random.get_state()
         
-        np.random.seed(random_state)
+        np.random.seed(seed)
         
         sample = self.model.resample(num_samples)
         


### PR DESCRIPTION
Right now, when using the sampling methods, in order to get the same result everytime, we need to do the following things:

1. invoke `np.random.seed(seed_value)`
2. invoke `random.set_state(random_state_tuple)`

outside of the function being called (i.e. `sample`). This is what people call a "leaky abstraction", in software engineering. An easy way to cope with this is to include the seed as a parameter in the `sample` method. Usually, we just take that seed, use it as an input for something like `sklearn.check_random_state` and we receive a random numbers generator as an output, using it instead of `numpy.random`. But since the code for some classes is using functions that allow us to pass the seed or random numbers generator instantiated by us, we need to be a little bit more sophisticated by using `numpy.random.get_state`, `numpy.random.set_state`, `random.getstate` and `random.setstate`.