### PR TITLE
Issue 67: Fix linting issues arisen by flake8==3.6.0

### DIFF
--- a/copulas/bivariate/clayton.py
+++ b/copulas/bivariate/clayton.py
@@ -106,7 +106,7 @@ class Clayton(Bivariate):
     def compute_theta(self):
         """Compute theta parameter using Kendall's tau.
 
-        On Clayton copula this is :math:`τ = θ/(θ + 2) \implies θ = 2τ/(1-τ)` with
+        On Clayton copula this is :math:`τ = θ/(θ + 2) \\implies θ = 2τ/(1-τ)` with
         :math:`θ ∈ (0, ∞)`.
 
         On the corner case of :math:`τ = 1`, a big enough number is returned instead of infinity.

--- a/copulas/bivariate/frank.py
+++ b/copulas/bivariate/frank.py
@@ -124,8 +124,8 @@ class Frank(Bivariate):
         """Compute theta parameter using Kendall's tau.
 
         On Frank copula, this is
-        :math:`τ = 1 − \\frac{4}{θ} + \\frac{4}{θ^2}\int_0^θ \! \\frac{t}{e^t -1} \, \mathrm{d}t.`.
-
+        :math:`τ = 1 − \\frac{4}{θ} + \\frac{4}{θ^2}\\int_0^θ \\!
+        \\frac{t}{e^t -1} \\, \\mathrm{d}t`.
 
         """
         return fsolve(self._frank_help, 1, args=(self.tau))[0]

--- a/copulas/multivariate/tree.py
+++ b/copulas/multivariate/tree.py
@@ -470,10 +470,10 @@ class Edge(object):
         This function will return true if the two edges are adjacent
         """
         return (
-            self.L == another_edge.L or
-            self.L == another_edge.R or
-            self.R == another_edge.L or
-            self.R == another_edge.R
+            self.L == another_edge.L
+            or self.L == another_edge.R
+            or self.R == another_edge.L
+            or self.R == another_edge.R
         )
 
     @staticmethod

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ universal = 1
 [flake8]
 max-line-length = 99
 exclude = docs, .git, __pycache__, .ipynb_checkpoints
-ignore = # Keep empty to prevent default ignores
+ignore = W503
 
 [isort]
 include_trailing_comment = True


### PR DESCRIPTION
The latest version of flake8 raises errors for invalid scaped caracthers, like the ones used in the LaTeX of some docstrings, it also forces to choose between having the binary operators after or before a line break.

Both of this changes break the build on TravisCI as seen here: https://github.com/DAI-Lab/Copulas/pull/66.