### PR TITLE
Correct docstring about VineCopula class

### DIFF
--- a/copulas/multivariate/vine.py
+++ b/copulas/multivariate/vine.py
@@ -18,7 +18,7 @@ class VineCopula(Multivariate):
         """Instantiate a vine copula class.
 
         Args:
-            :param vine_type: type of the vine copula, could be 'cvine','dvine','rvine'
+            :param vine_type: type of the vine copula, could be 'center','direct','regular'
             :type vine_type: string
         """
         super().__init__()
@@ -53,6 +53,7 @@ class VineCopula(Multivariate):
         self.train_vine(self.type)
 
     def train_vine(self, tree_type):
+        """Train vine."""
         LOGGER.debug('start building tree : 0')
         tree_1 = Tree(tree_type)
         tree_1.fit(0, self.n_var, self.tau_mat, self.u_matrix)


### PR DESCRIPTION
Edit the docstring about 'VineCopula' class in 'vine.py'.

Change its value on docstring:
- from 'cvine','dvine','rvine'
- to 'center','direct','regular'.

Base the information from testcase in 'test_vine.py'.

Reference to docstring:
[vine.py docstring](https://github.com/DAI-Lab/Copulas/blob/eb95657c0620777348c38b1f907a503b7244e43a/copulas/multivariate/vine.py#L21)

Reference to code:
[test_vine.py code](https://github.com/DAI-Lab/Copulas/blob/eb95657c0620777348c38b1f907a503b7244e43a/tests/copulas/multivariate/test_vine.py#L38-L45)

Address issue #65.