### PR TITLE
Issue 75: Fix error on vine sampling

### DIFF
--- a/copulas/multivariate/tree.py
+++ b/copulas/multivariate/tree.py
@@ -319,7 +319,7 @@ class CenterTree(Tree):
             ind = int(tau_sorted[itr, 0])
             name, theta = Bivariate.select_copula(self.u_matrix[:, (0, ind)])
 
-            new_edge = Edge(0, ind, name, theta)
+            new_edge = Edge(itr, 0, ind, name, theta)
             new_edge.tau = self.tau_matrix[0, ind]
             self.edges.append(new_edge)
 
@@ -332,7 +332,7 @@ class CenterTree(Tree):
         for itr in range(self.n_nodes - 1):
             right = int(aux_sorted[itr, 0])
             left_parent, right_parent = Edge.sort_edge([edges[anchor], edges[right]])
-            new_edge = Edge.get_child_edge(left_parent, right_parent)
+            new_edge = Edge.get_child_edge(itr, left_parent, right_parent)
             new_edge.tau = aux_sorted[itr, 1]
             self.edges.append(new_edge)
 
@@ -383,7 +383,7 @@ class DirectTree(Tree):
             name, theta = Bivariate.select_copula(self.u_matrix[:, (T1[k], T1[k + 1])])
 
             left, right = sorted([T1[k], T1[k + 1]])
-            new_edge = Edge(left, right, name, theta)
+            new_edge = Edge(k, left, right, name, theta)
             new_edge.tau = tau_T1[k]
             self.edges.append(new_edge)
 
@@ -391,7 +391,7 @@ class DirectTree(Tree):
         edges = self.previous_tree.edges
         for k in range(self.n_nodes - 1):
             left_parent, right_parent = Edge.sort_edge([edges[k], edges[k + 1]])
-            new_edge = Edge.get_child_edge(left_parent, right_parent)
+            new_edge = Edge.get_child_edge(k, left_parent, right_parent)
             new_edge.tau = self.tau_matrix[k, k + 1]
             self.edges.append(new_edge)
 
@@ -419,7 +419,7 @@ class RegularTree(Tree):
             name, theta = Bivariate.select_copula(self.u_matrix[:, (edge[0], edge[1])])
 
             left, right = sorted([edge[0], edge[1]])
-            new_edge = Edge(left, right, name, theta)
+            new_edge = Edge(len(X) - 1, left, right, name, theta)
             new_edge.tau = self.tau_matrix[edge[0], edge[1]]
             self.edges.append(new_edge)
             X.add(edge[1])
@@ -447,7 +447,7 @@ class RegularTree(Tree):
             pairs = sorted(adj_set, key=lambda e: neg_tau[e[0]][e[1]])[0]
             left_parent, right_parent = Edge.sort_edge([edges[pairs[0]], edges[pairs[1]]])
 
-            new_edge = Edge.get_child_edge(left_parent, right_parent)
+            new_edge = Edge.get_child_edge(len(visited) - 1, left_parent, right_parent)
             new_edge.tau = self.tau_matrix[pairs[0], pairs[1]]
             self.edges.append(new_edge)
 
@@ -456,7 +456,7 @@ class RegularTree(Tree):
 
 
 class Edge(object):
-    def __init__(self, left, right, copula_name, copula_theta):
+    def __init__(self, index, left, right, copula_name, copula_theta):
         """Initialize an Edge object.
 
         Args:
@@ -466,6 +466,7 @@ class Edge(object):
             :param copula_theta: parameters of the fitted copula class
 
         """
+        self.index = index
         self.L = left
         self.R = right
         self.D = set()  # dependence_set
@@ -537,13 +538,13 @@ class Edge(object):
         return left_u, right_u
 
     @classmethod
-    def get_child_edge(cls, left_parent, right_parent):
+    def get_child_edge(cls, index, left_parent, right_parent):
         """Construct a child edge from two parent edges."""
         [ed1, ed2, depend_set] = cls._identify_eds_ing(left_parent, right_parent)
         left_u, right_u = cls.get_conditional_uni(left_parent, right_parent)
         X = np.array([[x, y] for x, y in zip(left_u, right_u)])
         name, theta = Bivariate.select_copula(X)
-        new_edge = Edge(ed1, ed2, name, theta)
+        new_edge = Edge(index, ed1, ed2, name, theta)
         new_edge.D = depend_set
         new_edge.parents = [left_parent, right_parent]
         return new_edge
@@ -582,6 +583,7 @@ class Edge(object):
             U = self.U.tolist()
 
         return {
+            'index': self.index,
             'L': self.L,
             'R': self.R,
             'D': self.D,
@@ -596,7 +598,10 @@ class Edge(object):
 
     @classmethod
     def from_dict(cls, edge_dict):
-        instance = cls(edge_dict['L'], edge_dict['R'], edge_dict['name'], edge_dict['theta'])
+        instance = cls(
+            edge_dict['index'], edge_dict['L'], edge_dict['R'],
+            edge_dict['name'], edge_dict['theta']
+        )
         instance.U = np.array(edge_dict['U'])
         parents = edge_dict['parents']
 

--- a/copulas/multivariate/vine.py
+++ b/copulas/multivariate/vine.py
@@ -171,7 +171,9 @@ class VineCopula(Multivariate):
                                 condition = set(edge.D)
                                 condition.add(edge.L)
                                 condition.add(edge.R)
-                                visit_set = set(visited).add(current)
+
+                                visit_set = set(visited)
+                                visit_set.add(current)
 
                                 if condition.issubset(visit_set):
                                     current_ind = edge.index
@@ -180,19 +182,19 @@ class VineCopula(Multivariate):
                     if current_ind != -1:
                         # the node is not indepedent contional on visited node
                         copula_type = current_tree[current_ind].name
-                        copula_para = current_tree[current_ind].param
-                        cop = Bivariate(CopulaTypes(copula_type))
-                        derivative = cop.get_h_function()
-                        # start with last level
+                        copula = Bivariate(CopulaTypes(copula_type))
+                        copula.theta = current_tree[current_ind].theta
+                        derivative = copula._partial_derivative
+
                         if i == itr - 1:
                             tmp = optimize.fminbound(
                                 derivative, EPSILON, 1.0,
-                                args=(unis[visited[0]], copula_para, unis[current])
+                                args=(unis[visited[0]], unis[current])
                             )
                         else:
                             tmp = optimize.fminbound(
                                 derivative, EPSILON, 1.0,
-                                args=(unis[visited[0]], copula_para, tmp)
+                                args=(unis[visited[0]], tmp)
                             )
 
                         tmp = min(max(tmp, EPSILON), 0.99)

--- a/tests/copulas/multivariate/test_tree.py
+++ b/tests/copulas/multivariate/test_tree.py
@@ -334,9 +334,9 @@ class TestDirectTree(TestCase):
 
 class TestEdge(TestCase):
     def setUp(self):
-        self.e1 = Edge(2, 5, 'clayton', 1.5)
+        self.e1 = Edge(0, 2, 5, 'clayton', 1.5)
         self.e1.D = [1, 3]
-        self.e2 = Edge(3, 4, 'clayton', 1.5)
+        self.e2 = Edge(1, 3, 4, 'clayton', 1.5)
         self.e2.D = [1, 5]
 
     def test_identify_eds(self):
@@ -353,9 +353,10 @@ class TestEdge(TestCase):
     def test_to_dict(self):
         """To_dict returns a dictionary with the parameters to recreate an edge."""
         # Setup
-        edge = Edge(2, 5, 'clayton', 1.5)
+        edge = Edge(1, 2, 5, 'clayton', 1.5)
         edge.D = [1, 3]
         expected_result = {
+            'index': 1,
             'L': 2,
             'R': 5,
             'name': 'clayton',
@@ -378,6 +379,7 @@ class TestEdge(TestCase):
         """From_dict sets the dictionary values as instance attributes."""
         # Setup
         parameters = {
+            'index': 0,
             'L': 2,
             'R': 5,
             'name': 'clayton',
@@ -394,6 +396,7 @@ class TestEdge(TestCase):
         edge = Edge.from_dict(parameters)
 
         # Check
+        assert edge.index == 0
         assert edge.L == 2
         assert edge.R == 5
         assert edge.name == 'clayton'
@@ -405,7 +408,7 @@ class TestEdge(TestCase):
 
     def test_valid_serialization(self):
         # Setup
-        instance = Edge(2, 5, 'clayton', 1.5)
+        instance = Edge(0, 2, 5, 'clayton', 1.5)
 
         # Run
         result = Edge.from_dict(instance.to_dict())

--- a/tests/copulas/multivariate/test_vine.py
+++ b/tests/copulas/multivariate/test_vine.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from copulas.multivariate.base import Multivariate
-from copulas.multivariate.tree import Tree
+from copulas.multivariate.tree import Tree, TreeTypes
 from copulas.multivariate.vine import VineCopula
 from copulas.univariate import KDEUnivariate
 from tests import compare_nested_dicts
@@ -39,13 +39,13 @@ class TestVine(TestCase):
             ])
         })
 
-        self.rvine = VineCopula('regular')
+        self.rvine = VineCopula(TreeTypes.REGULAR)
         self.rvine.fit(data)
 
-        self.cvine = VineCopula('center')
+        self.cvine = VineCopula(TreeTypes.CENTER)
         self.cvine.fit(data)
 
-        self.dvine = VineCopula('direct')
+        self.dvine = VineCopula(TreeTypes.DIRECT)
         self.dvine.fit(data)
 
     def test_get_likelihood(self):
@@ -205,3 +205,21 @@ class TestVine(TestCase):
 
         # Check
         compare_nested_dicts(result.to_dict(), instance.to_dict())
+
+    def test_sample(self):
+        """After being fit, a vine can sample new data."""
+        # Setup
+        vine = VineCopula(TreeTypes.REGULAR)
+        X = pd.DataFrame([
+            [1, 0, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1]
+        ])
+        vine.fit(X)
+
+        # Run
+        result = vine.sample()
+
+        # Check
+        assert len(result) == vine.n_var


### PR DESCRIPTION
Resolve #75 

- Add `index` attribute on `copulas.multivariate.tree.Edge`
- Fix a wrong assignement to None
- Delete unnecesary argument on `fminbound` call.
- Update unittests for the Edge and Tree classes.
- Create a new unittest for sampling vines
