### PR TITLE
Issue 82: Add ability to handle constant data with Univariate

### DIFF
--- a/copulas/univariate/base.py
+++ b/copulas/univariate/base.py
@@ -105,16 +105,12 @@ class Univariate(object):
         if not self.fitted:
             raise NotFittedError("This model is not fitted.")
 
-    def check_constant_value(self):
-        if self.constant_value:
-            raise ValueError('This method is not available on constant distributions.')
-
     @staticmethod
     def _get_constant_value(X):
         """Checks if a Series or array contains only one unique value.
 
         Args:
-            X(pandas.Series or numpy.array): Array to check for constantness
+            X(pandas.Series or numpy.ndarray): Array to check for constantness
 
         Returns:
             (float or None): Return the constant value if there is one, else return None.
@@ -130,7 +126,7 @@ class Univariate(object):
             num_samples(int): Number of rows to sample
 
         Returns:
-            numpy.array: Sampled values. Array of shape (num_samples,).
+            numpy.ndarray: Sampled values. Array of shape (num_samples,).
         """
         return np.array([self.constant_value] * num_samples)
 
@@ -138,14 +134,48 @@ class Univariate(object):
         """Cumulative distribution for the degenerate case of constant distribution.
 
         Note that the output of this method will be an array whose unique values are 0 and 1.
+        More information can be found here: https://en.wikipedia.org/wiki/Degenerate_distribution
 
         Args:
-            X (numpy.array): Values to compute cdf to.
+            X (numpy.ndarray): Values to compute cdf to.
 
         Returns:
-            numpy.array: Cumulative distribution for the given values.
+            numpy.ndarray: Cumulative distribution for the given values.
         """
         result = np.ones(X.shape)
         result[np.nonzero(X < self.constant_value)] = 0
 
         return result
+
+    def _constant_probability_density(self, X):
+        """Probability density for the degenerate case of constant distribution.
+
+        Note that the output of this method will be an array whose unique values are 0 and 1.
+        More information can be found here: https://en.wikipedia.org/wiki/Degenerate_distribution
+
+        Args:
+            X(numpy.ndarray): Values to compute pdf.
+
+        Returns:
+            numpy.ndarray: Probability densisty for the given values
+        """
+        result = np.zeros(X.shape)
+        result[np.nonzero(X == self.constant_value)] = 1
+
+        return result
+
+    def _constant_percent_point(self, X):
+        """Percent point for the degenerate case of constant distribution.
+
+        Note that the output of this method will be an array whose unique values are `np.nan`
+        and self.constant_value.
+        More information can be found here: https://en.wikipedia.org/wiki/Degenerate_distribution
+
+        Args:
+            X(numpy.ndarray): Percentiles.
+
+        Returns:
+            numpy.ndarray:
+
+        """
+        return np.full(X.shape, self.constant_value)

--- a/copulas/univariate/base.py
+++ b/copulas/univariate/base.py
@@ -128,7 +128,7 @@ class Univariate(object):
         Returns:
             numpy.ndarray: Sampled values. Array of shape (num_samples,).
         """
-        return np.array([self.constant_value] * num_samples)
+        return np.full(num_samples, self.constant_value)
 
     def _constant_cumulative_distribution(self, X):
         """Cumulative distribution for the degenerate case of constant distribution.
@@ -179,3 +179,10 @@ class Univariate(object):
 
         """
         return np.full(X.shape, self.constant_value)
+
+    def _replace_constant_methods(self):
+        """Replaces conventional distribution methods by its constant counterparts."""
+        self.cumulative_distribution = self._constant_cumulative_distribution
+        self.percent_point = self._constant_percent_point
+        self.probability_density = self._constant_probability_density
+        self.sample = self._constant_sample

--- a/copulas/univariate/gaussian.py
+++ b/copulas/univariate/gaussian.py
@@ -47,9 +47,12 @@ class GaussianUnivariate(Univariate):
 
         self.constant_value = self._get_constant_value(X)
 
-        if not self.constant_value:
+        if self.constant_value is None:
             self.mean = np.mean(X)
             self.std = np.std(X)
+
+        else:
+            self._replace_constant_methods()
 
         self.fitted = True
 
@@ -63,9 +66,6 @@ class GaussianUnivariate(Univariate):
             np.ndarray
         """
         self.check_fit()
-        if self.constant_value:
-            return self._constant_probability_density(X)
-
         return norm.pdf(X, loc=self.mean, scale=self.std)
 
     def cumulative_distribution(self, X):
@@ -78,9 +78,6 @@ class GaussianUnivariate(Univariate):
             np.ndarray: Cumulative density for X.
         """
         self.check_fit()
-        if self.constant_value:
-            return self._constant_cumulative_distribution(X)
-
         return norm.cdf(X, loc=self.mean, scale=self.std)
 
     def percent_point(self, U):
@@ -93,9 +90,6 @@ class GaussianUnivariate(Univariate):
             `np.ndarray`: Estimated values in original space.
         """
         self.check_fit()
-        if self.constant_value:
-            return self._constant_percent_point(U)
-
         return norm.ppf(U, loc=self.mean, scale=self.std)
 
     def sample(self, num_samples=1):
@@ -108,9 +102,6 @@ class GaussianUnivariate(Univariate):
             np.ndarray: Generated samples
         """
         self.check_fit()
-        if self.constant_value:
-            return self._constant_sample(num_samples)
-
         return np.random.normal(self.mean, self.std, num_samples)
 
     def _fit_params(self):

--- a/copulas/univariate/gaussian.py
+++ b/copulas/univariate/gaussian.py
@@ -63,7 +63,9 @@ class GaussianUnivariate(Univariate):
             np.ndarray
         """
         self.check_fit()
-        self.check_constant_value()
+        if self.constant_value:
+            return self._constant_probability_density(X)
+
         return norm.pdf(X, loc=self.mean, scale=self.std)
 
     def cumulative_distribution(self, X):
@@ -91,7 +93,9 @@ class GaussianUnivariate(Univariate):
             `np.ndarray`: Estimated values in original space.
         """
         self.check_fit()
-        self.check_constant_value()
+        if self.constant_value:
+            return self._constant_percent_point(U)
+
         return norm.ppf(U, loc=self.mean, scale=self.std)
 
     def sample(self, num_samples=1):

--- a/copulas/univariate/kde.py
+++ b/copulas/univariate/kde.py
@@ -28,8 +28,11 @@ class KDEUnivariate(Univariate):
 
         self.constant_value = self._get_constant_value(X)
 
-        if not self.constant_value:
+        if self.constant_value is None:
             self.model = scipy.stats.gaussian_kde(X)
+
+        else:
+            self._replace_constant_methods()
 
         self.fitted = True
 
@@ -44,8 +47,6 @@ class KDEUnivariate(Univariate):
             pdf: int or float with the value of estimated pdf
         """
         self.check_fit()
-        if self.constant_value:
-            return self._constant_probability_density(X)
 
         if type(X) not in (int, float):
             raise ValueError('x must be int or float')
@@ -63,8 +64,6 @@ class KDEUnivariate(Univariate):
             float: estimated cumulative distribution.
         """
         self.check_fit()
-        if self.constant_value:
-            return self._constant_cumulative_distribution(X)
 
         low_bounds = self.model.dataset.mean() - (5 * self.model.dataset.std())
         return self.model.integrate_box_1d(low_bounds, X) - U
@@ -79,8 +78,6 @@ class KDEUnivariate(Univariate):
             float: value in original space
         """
         self.check_fit()
-        if self.constant_value:
-            return self._constant_percent_point(U)
 
         if not 0 < U < 1:
             raise ValueError('cdf value must be in [0,1]')
@@ -97,8 +94,6 @@ class KDEUnivariate(Univariate):
             samples: a list of datapoints sampled from the model
         """
         self.check_fit()
-        if self.constant_value:
-            return self._constant_sample(num_samples)
 
         return self.model.resample(num_samples)
 

--- a/copulas/univariate/kde.py
+++ b/copulas/univariate/kde.py
@@ -44,7 +44,9 @@ class KDEUnivariate(Univariate):
             pdf: int or float with the value of estimated pdf
         """
         self.check_fit()
-        self.check_constant_value()
+        if self.constant_value:
+            return self._constant_probability_density(X)
+
         if type(X) not in (int, float):
             raise ValueError('x must be int or float')
 
@@ -77,7 +79,9 @@ class KDEUnivariate(Univariate):
             float: value in original space
         """
         self.check_fit()
-        self.check_constant_value()
+        if self.constant_value:
+            return self._constant_percent_point(U)
+
         if not 0 < U < 1:
             raise ValueError('cdf value must be in [0,1]')
 

--- a/copulas/univariate/kde.py
+++ b/copulas/univariate/kde.py
@@ -26,7 +26,11 @@ class KDEUnivariate(Univariate):
         if not len(X):
             raise ValueError("data cannot be empty")
 
-        self.model = scipy.stats.gaussian_kde(X)
+        self.constant_value = self._get_constant_value(X)
+
+        if not self.constant_value:
+            self.model = scipy.stats.gaussian_kde(X)
+
         self.fitted = True
 
     def probability_density(self, X):
@@ -40,6 +44,7 @@ class KDEUnivariate(Univariate):
             pdf: int or float with the value of estimated pdf
         """
         self.check_fit()
+        self.check_constant_value()
         if type(X) not in (int, float):
             raise ValueError('x must be int or float')
 
@@ -49,13 +54,16 @@ class KDEUnivariate(Univariate):
         """Computes the integral of a 1-D pdf between two bounds
 
         Args:
-            X: `float` a datapoint.
-            U: `float` cdf value in [0,1], only used in get_ppf
+            X(float): a datapoint.
+            U(float): cdf value in [0,1], only used in get_ppf
 
         Returns:
             float: estimated cumulative distribution.
         """
         self.check_fit()
+        if self.constant_value:
+            return self._constant_cumulative_distribution(X)
+
         low_bounds = self.model.dataset.mean() - (5 * self.model.dataset.std())
         return self.model.integrate_box_1d(low_bounds, X) - U
 
@@ -69,6 +77,7 @@ class KDEUnivariate(Univariate):
             float: value in original space
         """
         self.check_fit()
+        self.check_constant_value()
         if not 0 < U < 1:
             raise ValueError('cdf value must be in [0,1]')
 
@@ -78,12 +87,15 @@ class KDEUnivariate(Univariate):
         """Samples new data point based on model.
 
         Args:
-            num_samples: `int` number of points to be sampled
+            num_samples(int): number of points to be sampled
 
         Returns:
             samples: a list of datapoints sampled from the model
         """
         self.check_fit()
+        if self.constant_value:
+            return self._constant_sample(num_samples)
+
         return self.model.resample(num_samples)
 
     @classmethod
@@ -91,7 +103,10 @@ class KDEUnivariate(Univariate):
         """Set attributes with provided values."""
         instance = cls()
 
-        if copula_dict['fitted']:
+        instance.fitted = copula_dict['fitted']
+        instance.constant_value = copula_dict['constant_value']
+
+        if instance.fitted and not instance.constant_value:
             instance.model = scipy.stats.gaussian_kde([-1, 0, 0])
 
             for key in ['dataset', 'covariance', 'inv_cov']:
@@ -100,8 +115,6 @@ class KDEUnivariate(Univariate):
             attributes = ['d', 'n', 'dataset', 'covariance', 'factor', 'inv_cov']
             for name in attributes:
                 setattr(instance.model, name, copula_dict[name])
-
-        instance.fitted = copula_dict['fitted']
 
         return instance
 

--- a/tests/copulas/multivariate/test_gaussian_copula.py
+++ b/tests/copulas/multivariate/test_gaussian_copula.py
@@ -289,25 +289,29 @@ class TestGaussianCopula(TestCase):
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 5.843333333333334,
                     'std': 0.8253012917851409,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 },
                 'feature_02': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.0540000000000003,
                     'std': 0.4321465800705435,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 },
                 'feature_03': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.758666666666666,
                     'std': 1.7585291834055212,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 },
                 'feature_04': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 1.1986666666666668,
                     'std': 0.7606126185881716,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 }
             }
         }
@@ -337,25 +341,29 @@ class TestGaussianCopula(TestCase):
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 5.843333333333334,
                     'std': 0.8253012917851409,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 },
                 'feature_02': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.0540000000000003,
                     'std': 0.4321465800705435,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 },
                 'feature_03': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.758666666666666,
                     'std': 1.7585291834055212,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 },
                 'feature_04': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 1.1986666666666668,
                     'std': 0.7606126185881716,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 }
             }
         }
@@ -386,7 +394,7 @@ class TestGaussianCopula(TestCase):
             [0.8776048563471857, -0.4233383520816991, 1.006711409395973, 0.9692185540781536],
             [0.823443255069628, -0.3589370029669186, 0.9692185540781536, 1.0067114093959735]
         ]
-        parameters = {
+        expected_content = {
             'covariance': covariance,
             'fitted': True,
             'type': 'copulas.multivariate.gaussian.GaussianMultivariate',
@@ -396,29 +404,32 @@ class TestGaussianCopula(TestCase):
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 5.843333333333334,
                     'std': 0.8253012917851409,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 },
                 'feature_02': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.0540000000000003,
                     'std': 0.4321465800705435,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 },
                 'feature_03': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.758666666666666,
                     'std': 1.7585291834055212,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 },
                 'feature_04': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 1.1986666666666668,
                     'std': 0.7606126185881716,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 }
             }
         }
-        expected_content = parameters
 
         # Run
         instance.save('test.json')
@@ -448,25 +459,29 @@ class TestGaussianCopula(TestCase):
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 5.843333333333334,
                     'std': 0.8253012917851409,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 },
                 'feature_02': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.0540000000000003,
                     'std': 0.4321465800705435,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 },
                 'feature_03': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.758666666666666,
                     'std': 1.7585291834055212,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 },
                 'feature_04': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 1.1986666666666668,
                     'std': 0.7606126185881716,
-                    'fitted': True
+                    'fitted': True,
+                    'constant_value': None
                 }
             }
         }

--- a/tests/copulas/multivariate/test_gaussian_copula.py
+++ b/tests/copulas/multivariate/test_gaussian_copula.py
@@ -501,3 +501,22 @@ class TestGaussianCopula(TestCase):
             assert instance.distribs[name].to_dict() == json_mock.return_value['distribs'][name]
 
         assert open_mock.called_once_with('test.json', 'r')
+
+    def test_sample_constant_column(self):
+        """ """
+        # Setup
+        instance = GaussianMultivariate()
+        X = np.array([
+            [1, 2],
+            [1, 3],
+            [1, 4],
+            [1, 5]
+        ])
+        instance.fit(X)
+
+        # Run
+        result = instance.sample(5)
+
+        # Check
+        assert result.shape == (5, 2)
+        assert result.loc[:, 0].equals(pd.Series([1, 1, 1, 1, 1], name=0))

--- a/tests/copulas/multivariate/test_vine.py
+++ b/tests/copulas/multivariate/test_vine.py
@@ -116,7 +116,8 @@ class TestVine(TestCase):
             'unis': [
                 {
                     'type': 'copulas.univariate.kde.KDEUnivariate',
-                    'fitted': False
+                    'fitted': False,
+                    'constant_value': None
                 }
             ]
         }
@@ -155,7 +156,8 @@ class TestVine(TestCase):
             'unis': [
                 {
                     'type': 'copulas.univariate.kde.KDEUnivariate',
-                    'fitted': False
+                    'fitted': False,
+                    'constant_value': None
                 }
             ]
         }

--- a/tests/copulas/univariate/test_base_univariate.py
+++ b/tests/copulas/univariate/test_base_univariate.py
@@ -8,16 +8,6 @@ from tests import compare_nested_iterables
 
 class TestUnivariate(TestCase):
 
-    def test_check_constant_value(self):
-        """If constant_value is not None, raises an exception."""
-        # Setup
-        instance = Univariate()
-        instance.constant_value = 5
-
-        # Run / Check
-        with self.assertRaises(ValueError):
-            instance.check_constant_value()
-
     def test_get_constant_value(self):
         """get_constant_value return the unique value of an array if it exists."""
         # Setup
@@ -67,6 +57,36 @@ class TestUnivariate(TestCase):
 
         # Run
         result = instance._constant_cumulative_distribution(X)
+
+        # Check
+        compare_nested_iterables(result, expected_result)
+
+    def test__constant_probability_density(self):
+        """constant_probability_density only is 1 in self.constant_value."""
+        # Setup
+        instance = Univariate()
+        instance.constant_value = 3
+
+        X = np.array([1, 2, 3, 4, 5])
+        expected_result = np.array([0, 0, 1, 0, 0])
+
+        # Run
+        result = instance._constant_probability_density(X)
+
+        # Check
+        compare_nested_iterables(result, expected_result)
+
+    def test__constant_percent_point(self):
+        """constant_percent_point only is self.constant_value in non-zero probabilities."""
+        # Setup
+        instance = Univariate()
+        instance.constant_value = 3
+
+        X = np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
+        expected_result = np.array([3, 3, 3, 3, 3])
+
+        # Run
+        result = instance._constant_percent_point(X)
 
         # Check
         compare_nested_iterables(result, expected_result)

--- a/tests/copulas/univariate/test_base_univariate.py
+++ b/tests/copulas/univariate/test_base_univariate.py
@@ -1,0 +1,72 @@
+from unittest import TestCase
+
+import numpy as np
+
+from copulas.univariate.base import Univariate
+from tests import compare_nested_iterables
+
+
+class TestUnivariate(TestCase):
+
+    def test_check_constant_value(self):
+        """If constant_value is not None, raises an exception."""
+        # Setup
+        instance = Univariate()
+        instance.constant_value = 5
+
+        # Run / Check
+        with self.assertRaises(ValueError):
+            instance.check_constant_value()
+
+    def test_get_constant_value(self):
+        """get_constant_value return the unique value of an array if it exists."""
+        # Setup
+        X = np.array([1, 1, 1, 1])
+        expected_result = 1
+
+        # Run
+        result = Univariate._get_constant_value(X)
+
+        # Check
+        assert result == expected_result
+
+    def test_get_constant_value_non_constant(self):
+        """get_constant_value return None on non-constant arrays."""
+        # Setup
+        X = np.array(range(5))
+        expected_result = None
+
+        # Run
+        result = Univariate._get_constant_value(X)
+
+        # Check
+        assert result is expected_result
+
+    def test__sample_sample(self):
+        """_constant_sample returns a constant array of num_samples length."""
+        # Setup
+        instance = Univariate()
+        instance.constant_value = 15
+
+        expected_result = np.array([15, 15, 15, 15, 15])
+
+        # Run
+        result = instance._constant_sample(5)
+
+        # Check
+        compare_nested_iterables(result, expected_result)
+
+    def test__constant_cumulative_distribution(self):
+        """constant_cumulative_distribution returns only 0 and 1."""
+        # Setup
+        instance = Univariate()
+        instance.constant_value = 3
+
+        X = np.array([1, 2, 3, 4, 5])
+        expected_result = np.array([0, 0, 1, 1, 1])
+
+        # Run
+        result = instance._constant_cumulative_distribution(X)
+
+        # Check
+        compare_nested_iterables(result, expected_result)

--- a/tests/copulas/univariate/test_gaussian.py
+++ b/tests/copulas/univariate/test_gaussian.py
@@ -116,6 +116,7 @@ class TestGaussianUnivariate(TestCase):
         # Setup
         instance = GaussianUnivariate()
         instance.constant_value = 3
+        instance._replace_constant_methods()
         instance.fitted = True
 
         X = np.array([1, 2, 3, 4, 5])
@@ -180,6 +181,7 @@ class TestGaussianUnivariate(TestCase):
         # Setup
         instance = GaussianUnivariate()
         instance.constant_value = 3
+        instance._replace_constant_methods()
         instance.fitted = True
 
         expected_result = np.array([3, 3, 3, 3, 3])

--- a/tests/copulas/univariate/test_gaussian.py
+++ b/tests/copulas/univariate/test_gaussian.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from copulas.univariate.gaussian import GaussianUnivariate
+from tests import compare_nested_iterables
 
 
 class TestGaussianUnivariate(TestCase):
@@ -43,18 +44,15 @@ class TestGaussianUnivariate(TestCase):
         # Setup
         copula = GaussianUnivariate()
         column = pd.Series([0, 1, 2, 3, 4, 5], name='column')
-        mean = 2.5
-        std = 1.707825127659933
-        name = 'column'
 
         # Run
         copula.fit(column)
 
         # Check
-        assert copula.mean == mean
-        assert copula.std == std
-        assert copula.name == name
-        assert copula.fitted
+        assert copula.mean == 2.5
+        assert copula.std == 1.707825127659933
+        assert copula.name == 'column'
+        assert copula.fitted is True
 
     def test_fit_empty_data(self):
         """On fit, if column is empty an error is raised."""
@@ -71,15 +69,16 @@ class TestGaussianUnivariate(TestCase):
         """On fit, even if column has equal values, std is never 0."""
 
         # Setup
-        copula = GaussianUnivariate()
-        column = [1, 1, 1, 1, 1, 1]
+        instance = GaussianUnivariate()
+        column = [5, 5, 5, 5, 5, 5]
 
         # Run
-        copula.fit(column)
+        instance.fit(column)
 
         # Check
-        assert copula.mean == 1
-        assert copula.std == 0.001
+        assert instance.mean == 0
+        assert instance.std == 1
+        assert instance.constant_value == 5
 
     def test_get_probability_density(self):
         """Probability_density returns the normal probability distribution for the given values."""
@@ -112,6 +111,22 @@ class TestGaussianUnivariate(TestCase):
         # Check
         assert (result == expected_result).all()
 
+    def test_cumulative_distribution_constant(self):
+        """cumulative_distribution can be computed for constant distribution."""
+        # Setup
+        instance = GaussianUnivariate()
+        instance.constant_value = 3
+        instance.fitted = True
+
+        X = np.array([1, 2, 3, 4, 5])
+        expected_result = np.array([0, 0, 1, 1, 1])
+
+        # Run
+        result = instance.cumulative_distribution(X)
+
+        # Check
+        compare_nested_iterables(result, expected_result)
+
     def test_percent_point(self):
         """Percent_point returns the original point from the cumulative probability value."""
 
@@ -135,15 +150,15 @@ class TestGaussianUnivariate(TestCase):
         copula = GaussianUnivariate()
         column = [-1, 0, 1]
         copula.fit(column)
-        initial_value = pd.Series([0])
+        initial_value = np.array([0, 0.1, 0.2, 0.3, 0.4, 0.5])
 
         # Run
         result_a = copula.percent_point(copula.cumulative_distribution(initial_value))
         result_b = copula.cumulative_distribution(copula.percent_point(initial_value))
 
         # Check
-        assert (initial_value == result_a).all()
-        assert (initial_value == result_b).all()
+        assert (initial_value - result_a < 10E-5).all()
+        assert (initial_value - result_b < 10E-5).all()
 
     def test_sample(self):
         """After fitting, GaussianUnivariate is able to sample new data."""
@@ -160,6 +175,21 @@ class TestGaussianUnivariate(TestCase):
         assert abs(np.mean(result) - copula.mean) < 10E-3
         assert abs(np.std(result) - copula.std) < 10E-3
 
+    def test_sample_constant(self):
+        """samples can be generated for constant distribution."""
+        # Setup
+        instance = GaussianUnivariate()
+        instance.constant_value = 3
+        instance.fitted = True
+
+        expected_result = np.array([3, 3, 3, 3, 3])
+
+        # Run
+        result = instance.sample(5)
+
+        # Check
+        compare_nested_iterables(result, expected_result)
+
     def test_to_dict(self):
         """To_dict returns the defining parameters of a distribution in a dict."""
         # Setup
@@ -170,7 +200,8 @@ class TestGaussianUnivariate(TestCase):
             'type': 'copulas.univariate.gaussian.GaussianUnivariate',
             'mean': 2.5,
             'std': 1.707825127659933,
-            'fitted': True
+            'fitted': True,
+            'constant_value': None
         }
 
         # Run
@@ -186,6 +217,7 @@ class TestGaussianUnivariate(TestCase):
             'mean': 2.5,
             'std': 1.707825127659933,
             'fitted': True,
+            'constant_value': None
         }
 
         # Run

--- a/tests/copulas/univariate/test_kde.py
+++ b/tests/copulas/univariate/test_kde.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""Tests for `univariate` package."""
+"""Tests for `univariate.kde` module."""
 
 from unittest import TestCase
+from unittest.mock import patch
 
 import numpy as np
-import scipy
 
 from copulas.univariate.kde import KDEUnivariate
-from tests import compare_nested_dicts
+from tests import compare_nested_dicts, compare_nested_iterables
 
 
 class TestKDEUnivariate(TestCase):
@@ -23,26 +23,46 @@ class TestKDEUnivariate(TestCase):
 
     def test___init__(self):
         """On init, model are set to None."""
-        self.kde = KDEUnivariate()
-        assert self.kde.model is None
+        # Setup / Run
+        instance = KDEUnivariate()
 
-    def test_fit(self):
-        """On fit, kde model is instantiated with intance of gaussian_kde."""
-        self.kde = KDEUnivariate()
-        data = [1, 2, 3, 4, 5]
+        # Check
+        instance.model is None
+        instance.fitted is False
+        instance.constant_value is None
 
-        self.kde.fit(data)
+    @patch('copulas.univariate.kde.scipy.stats.gaussian_kde', autospec=True)
+    def test_fit(self, kde_mock):
+        """On fit, a new instance of gaussian_kde is fitted."""
+        # Setup
+        instance = KDEUnivariate()
+        X = np.array([1, 2, 3, 4, 5])
 
-        self.assertIsInstance(self.kde.model, scipy.stats.gaussian_kde)
+        kde_mock.return_value = 'mock model'
 
-    def test_fit_uniform(self):
-        """On fit, kde model is instantiated with passed data."""
-        self.kde = KDEUnivariate()
-        data = [1, 2, 3, 4, 5]
+        # Run
+        instance.fit(X)
 
-        self.kde.fit(data)
+        # Check
+        assert instance.model == 'mock model'
+        assert instance.fitted is True
+        assert instance.constant_value is None
 
-        assert self.kde.model
+        kde_mock.assert_called_once_with(X)
+
+    def test_fit_constant(self):
+        """If fit data is constant, no gaussian_kde model is created."""
+        # Setup
+        instance = KDEUnivariate()
+        X = np.array([1, 1, 1, 1, 1])
+
+        # Run
+        instance.fit(X)
+
+        # Check
+        assert instance.model is None
+        assert instance.constant_value == 1
+        assert instance.fitted is True
 
     def test_fit_empty_data(self):
         """If fitting kde model with empty data it will raise ValueError."""
@@ -90,6 +110,7 @@ class TestKDEUnivariate(TestCase):
         # Setup
         parameters = {
             'fitted': True,
+            'constant_value': None,
             'd': 1,
             'n': 10,
             'dataset': [[
@@ -152,6 +173,7 @@ class TestKDEUnivariate(TestCase):
         expected_result = {
             'type': 'copulas.univariate.kde.KDEUnivariate',
             'fitted': True,
+            'constant_value': None,
             'd': 1,
             'n': 10,
             'dataset': [[
@@ -200,3 +222,68 @@ class TestKDEUnivariate(TestCase):
 
         # Check
         assert instance.to_dict() == result.to_dict()
+
+    @patch('copulas.univariate.kde.scipy.stats.gaussian_kde', autospec=True)
+    def test_sample(self, kde_mock):
+        """When fitted, we are able to use the model to get samples."""
+        # Setup
+        instance = KDEUnivariate()
+        X = np.array([1, 2, 3, 4, 5])
+        instance.fit(X)
+
+        model_mock = kde_mock.return_value
+        model_mock.resample.return_value = np.array([0, 1, 0, 1, 0])
+
+        expected_result = np.array([0, 1, 0, 1, 0])
+
+        # Run
+        result = instance.sample(5)
+
+        # Check
+        compare_nested_iterables(result, expected_result)
+
+        assert instance.model == model_mock
+
+        kde_mock.assert_called_once_with(X)
+        model_mock.resample.assert_called_once_with(5)
+
+    def test_sample_constant(self):
+        """If constant_value is set, all the sample have the same value."""
+        # Setup
+        instance = KDEUnivariate()
+        instance.fitted = True
+        instance.constant_value = 3
+
+        expected_result = np.array([3, 3, 3, 3, 3])
+
+        # Run
+        result = instance.sample(5)
+
+        # Check
+        compare_nested_iterables(result, expected_result)
+
+    def test_probability_density_constant_raises(self):
+        """If constant_value, probability_density raises a ValueError."""
+        # Setup
+        instance = KDEUnivariate()
+        instance.fitted = True
+        instance.constant_value = 3
+
+        X = np.array([0.1, 0.5, 0.75])
+
+        # Run / Check
+        with self.assertRaises(ValueError):
+            instance.probability_density(X)
+
+    def test_percent_point_constant_raises(self):
+        """If constant_value, percent_point raises a ValueError."""
+        # Setup
+        instance = KDEUnivariate()
+        instance.fitted = True
+        instance.constant_value = 3
+
+        X = np.array([0.1, 0.5, 0.75])
+
+        # Run / Check
+        with self.assertRaises(ValueError):
+            instance.percent_point(X)

--- a/tests/copulas/univariate/test_kde.py
+++ b/tests/copulas/univariate/test_kde.py
@@ -262,28 +262,42 @@ class TestKDEUnivariate(TestCase):
         # Check
         compare_nested_iterables(result, expected_result)
 
-    def test_probability_density_constant_raises(self):
-        """If constant_value, probability_density raises a ValueError."""
+    @patch('copulas.univariate.base.Univariate._constant_probability_density', autospec=True)
+    def test_probability_density_constant(self, pdf_mock):
+        """If constant_value, probability_density uses the degenerate version."""
+        # Setup
+        instance = KDEUnivariate()
+        instance.fitted = True
+        instance.constant_value = 3
+
+        X = np.array([0, 1, 2, 3, 4, 5])
+        expected_result = np.array([0, 0, 1, 0, 0])
+
+        pdf_mock.return_value = np.array([0, 0, 1, 0, 0])
+
+        # Run
+        result = instance.probability_density(X)
+
+        # Check
+        compare_nested_iterables(result, expected_result)
+        pdf_mock.assert_called_once_with(instance, X)
+
+    @patch('copulas.univariate.base.Univariate._constant_percent_point', autospec=True)
+    def test_percent_point_constant_raises(self, ppf_mock):
+        """If constant_value, percent_point uses the degenerate version."""
         # Setup
         instance = KDEUnivariate()
         instance.fitted = True
         instance.constant_value = 3
 
         X = np.array([0.1, 0.5, 0.75])
+        expected_result = np.array([3, 3, 3])
 
-        # Run / Check
-        with self.assertRaises(ValueError):
-            instance.probability_density(X)
+        ppf_mock.return_value = np.array([3, 3, 3])
 
-    def test_percent_point_constant_raises(self):
-        """If constant_value, percent_point raises a ValueError."""
-        # Setup
-        instance = KDEUnivariate()
-        instance.fitted = True
-        instance.constant_value = 3
+        # Run
+        result = instance.percent_point(X)
 
-        X = np.array([0.1, 0.5, 0.75])
-
-        # Run / Check
-        with self.assertRaises(ValueError):
-            instance.percent_point(X)
+        # Check
+        compare_nested_iterables(result, expected_result)
+        ppf_mock.assert_called_once_with(instance, X)

--- a/tests/copulas/univariate/test_kde.py
+++ b/tests/copulas/univariate/test_kde.py
@@ -253,6 +253,7 @@ class TestKDEUnivariate(TestCase):
         instance = KDEUnivariate()
         instance.fitted = True
         instance.constant_value = 3
+        instance._replace_constant_methods()
 
         expected_result = np.array([3, 3, 3, 3, 3])
 
@@ -269,6 +270,7 @@ class TestKDEUnivariate(TestCase):
         instance = KDEUnivariate()
         instance.fitted = True
         instance.constant_value = 3
+        instance._replace_constant_methods()
 
         X = np.array([0, 1, 2, 3, 4, 5])
         expected_result = np.array([0, 0, 1, 0, 0])
@@ -289,6 +291,7 @@ class TestKDEUnivariate(TestCase):
         instance = KDEUnivariate()
         instance.fitted = True
         instance.constant_value = 3
+        instance._replace_constant_methods()
 
         X = np.array([0.1, 0.5, 0.75])
         expected_result = np.array([3, 3, 3])


### PR DESCRIPTION
Add the statistical functions (`cdf`, `pdf`, `ppf`, `sample`) of the degenerate(constant) distribution on  `copulas.univariate.base.Univariate` so can be used when fit with single-valued data.

Resolves #82 also Resolves #57 