### PR TITLE
Issue 64: Fix error on VineCopula with breast_cancer dataset

### DIFF
--- a/copulas/__init__.py
+++ b/copulas/__init__.py
@@ -9,6 +9,7 @@ __version__ = '0.2.2-dev'
 import importlib
 
 import numpy as np
+import pandas as pd
 
 EPSILON = np.finfo(np.float32).eps
 
@@ -33,3 +34,37 @@ def get_qualified_name(_object):
         _class = _object.__class__.__name__
 
     return module + '.' + _class
+
+
+def check_valid_values(function):
+    """Raises an exception if the given values are not supported.
+
+    Args:
+        function(callable): Method whose unique argument is a numpy.array-like object.
+
+    Returns:
+        callable: Decorated function
+
+    Raises:
+        ValueError: If there are missing or invalid values or if the dataset is empty.
+    """
+    def decorated(self, X, *args, **kwargs):
+
+        if isinstance(X, pd.DataFrame):
+            W = X.values
+
+        else:
+            W = X
+
+        if not len(W):
+            raise ValueError('Your dataset is empty.')
+
+        if W.dtype not in [np.dtype('float64'), np.dtype('int64')]:
+            raise ValueError('There are non-numerical values in your data.')
+
+        if np.isnan(W).any().any():
+            raise ValueError('There are nan values in your data.')
+
+        return function(self, X, *args, **kwargs)
+
+    return decorated

--- a/copulas/multivariate/gaussian.py
+++ b/copulas/multivariate/gaussian.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from scipy import integrate, stats
 
-from copulas import get_qualified_name, import_object
+from copulas import check_valid_values, get_qualified_name, import_object
 from copulas.multivariate.base import Multivariate
 from copulas.univariate import Univariate
 
@@ -129,11 +129,12 @@ class GaussianMultivariate(Multivariate):
         result = result[(result != np.inf).all(axis=1)]
         return pd.DataFrame(data=result).cov().values
 
+    @check_valid_values
     def fit(self, X):
         """Compute the distribution for each variable and then its covariance matrix.
 
         Args:
-            X: `numpy.ndarray` or `pandas.DataFrame`. Data to model.
+            X(numpy.ndarray or pandas.DataFrame): Data to model.
 
         Returns:
             None

--- a/copulas/multivariate/tree.py
+++ b/copulas/multivariate/tree.py
@@ -480,25 +480,26 @@ class Edge(object):
         self.likelihood = None
 
     @staticmethod
-    def _identify_eds_ing(edge1, edge2):
+    def _identify_eds_ing(first, second):
         """Find nodes connecting adjacent edges.
 
         Args:
-            :param edge1: edge object representing edge1
-            :param edge2: edge object representing edge2
-            :type edge1: Edge object
-            :type edge2: Edge object
-            :return left,right: end node indices of the new edge
-            :return depend_set: new dependence set
-            :type left, right, ing: int
-            :type depend_set: set
+            first(Edge): Edge object representing the first edge.
+            second(Edge): Edge object representing the second edge.
+
+        Returns:
+            tuple[int, int, set[int]]: The first two values represent left and right node
+                indicies of the new edge. The third value is the new dependence set.
         """
-        A = set([edge1.L, edge1.R])
-        A.update(edge1.D)
-        B = set([edge2.L, edge2.R])
-        B.update(edge2.D)
+        A = set([first.L, first.R])
+        A.update(first.D)
+
+        B = set([second.L, second.R])
+        B.update(second.D)
+
         depend_set = A & B
         left, right = sorted(list(A ^ B))
+
         return left, right, depend_set
 
     def is_adjacent(self, another_edge):
@@ -508,7 +509,7 @@ class Edge(object):
             :param another_edge: edge object of another edge
             :type another_edge: edge object
 
-        This function will return true if the two edges are adjacent
+        This function will return true if the two edges are adjacent.
         """
         return (
             self.L == another_edge.L
@@ -519,18 +520,28 @@ class Edge(object):
 
     @staticmethod
     def sort_edge(edges):
-        """Sort edge object first by left node indices then right.
+        """Sort iterable of edges first by left node indices then right.
 
         Args:
-            :param edges: list of edges need to be sorted
-            :type edges: list
+            edges(list[Edge]): List of edges to be sorted.
+
+        Returns:
+            list[Edge]: Sorted list by left and right node indices.
         """
         return sorted(edges, key=lambda x: (x.L, x.R))
 
     @classmethod
     def get_conditional_uni(cls, left_parent, right_parent):
-        """Identify pair univariate value from parents."""
-        left, right, depend_set = cls._identify_eds_ing(left_parent, right_parent)
+        """Identify pair univariate value from parents.
+
+        Args:
+            left_parent(Edge): left parent
+            right_parent(Edge): right parent
+
+        Returns:
+            tuple[np.ndarray, np.ndarray]: left and right parents univariate.
+        """
+        left, right, _ = cls._identify_eds_ing(left_parent, right_parent)
 
         left_u = left_parent.U[0] if left_parent.L == left else left_parent.U[1]
         right_u = right_parent.U[0] if right_parent.L == right else right_parent.U[1]
@@ -550,7 +561,14 @@ class Edge(object):
         return new_edge
 
     def get_likelihood(self, uni_matrix):
-        """Compute likelihood given a U matrix."""
+        """Compute likelihood given a U matrix.
+
+        Args:
+            uni_matrix(numpy.array): Matrix to compute the likelihood.
+
+        Return:
+            tuple(np.ndarray, np.ndarray, np.array): likelihood and conditional values.
+        """
         if self.parents is None:
             left_u = uni_matrix[:, self.L]
             right_u = uni_matrix[:, self.R]

--- a/copulas/multivariate/tree.py
+++ b/copulas/multivariate/tree.py
@@ -181,7 +181,7 @@ class Tree(Multivariate):
 
     def prepare_next_tree(self):
         """Prepare conditional U matrix for next tree."""
-        for index, edge in enumerate(self.edges):
+        for edge in self.edges:
             copula_theta = edge.theta
 
             if self.level == 1:
@@ -214,14 +214,11 @@ class Tree(Multivariate):
         """Compute likelihood of the tree given an U matrix.
 
         Args:
-            :param uni_matrix: univariate matrix to evaluate likelihood on
-            :type uni_matrix: a np.ndarray
+            uni_matrix(numpy.array): univariate matrix to evaluate likelihood on.
 
         Returns:
-            param value: likelihood value of the current tree
-            param new_uni_matrix: next level onditional univariate matrix
-            type value: float or int
-            type new_uni_matrix: np.ndarray
+            tuple[float, numpy.array]:
+                likelihood of the current tree, next level conditional univariate matrix
         """
         uni_dim = uni_matrix.shape[1]
         num_edge = len(self.edges)

--- a/copulas/multivariate/tree.py
+++ b/copulas/multivariate/tree.py
@@ -181,7 +181,7 @@ class Tree(Multivariate):
 
     def prepare_next_tree(self):
         """Prepare conditional U matrix for next tree."""
-        for edge in self.edges:
+        for index, edge in enumerate(self.edges):
             copula_theta = edge.theta
 
             if self.level == 1:
@@ -199,9 +199,9 @@ class Tree(Multivariate):
             X_right_left = np.array([[x, y] for x, y in zip(right_u, left_u)])
 
             copula = Bivariate(edge.name)
-            copula.fit(X_left_right)
-            left_given_right = copula.partial_derivative(X_left_right, copula_theta)
-            right_given_left = copula.partial_derivative(X_right_left, copula_theta)
+            copula.theta = copula_theta
+            left_given_right = copula.partial_derivative(X_left_right)
+            right_given_left = copula.partial_derivative(X_right_left)
 
             # correction of 0 or 1
             left_given_right[left_given_right == 0] = EPSILON

--- a/copulas/multivariate/vine.py
+++ b/copulas/multivariate/vine.py
@@ -4,7 +4,7 @@ from random import randint
 import numpy as np
 from scipy import optimize
 
-from copulas import EPSILON, get_qualified_name
+from copulas import EPSILON, check_valid_values, get_qualified_name
 from copulas.bivariate.base import Bivariate, CopulaTypes
 from copulas.multivariate.base import Multivariate
 from copulas.multivariate.tree import Tree
@@ -78,6 +78,7 @@ class VineCopula(Multivariate):
 
         return instance
 
+    @check_valid_values
     def fit(self, X, truncated=3):
         """Fit a vine model to the data.
 

--- a/copulas/univariate/gaussian.py
+++ b/copulas/univariate/gaussian.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 from scipy.stats import norm
 
+from copulas import check_valid_values
 from copulas.univariate.base import Univariate
 
 LOGGER = logging.getLogger(__name__)
@@ -29,6 +30,7 @@ class GaussianUnivariate(Univariate):
             'Standard deviation: {}'.format(*details)
         )
 
+    @check_valid_values
     def fit(self, X):
         """Fit the model.
 
@@ -38,10 +40,6 @@ class GaussianUnivariate(Univariate):
         Returns:
             None
         """
-
-        if not len(X):
-            raise ValueError("Can't fit with an empty dataset.")
-
         if isinstance(X, (pd.Series, pd.DataFrame)):
             self.name = X.name
         else:

--- a/copulas/univariate/kde.py
+++ b/copulas/univariate/kde.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy
 
+from copulas import check_valid_values
 from copulas.univariate.base import Univariate
 
 
@@ -14,6 +15,7 @@ class KDEUnivariate(Univariate):
         super(KDEUnivariate, self).__init__()
         self.model = None
 
+    @check_valid_values
     def fit(self, X):
         """Fit Kernel density estimation to an list of values.
 
@@ -23,8 +25,6 @@ class KDEUnivariate(Univariate):
         This function will fit a gaussian_kde model to a list of datapoints
         and store it as a class attribute.
         """
-        if not len(X):
-            raise ValueError("data cannot be empty")
 
         self.model = scipy.stats.gaussian_kde(X)
         self.fitted = True

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,25 +9,30 @@ def compare_nested_dicts(first, second, epsilon=10E-6):
 
     assert first.keys() == second.keys()
 
-    for key in first.keys():
-        if isinstance(first[key], dict):
-            compare_nested_dicts(first[key], second[key])
+    for key, _first in first.items():
+        _second = second[key]
+        if isinstance(_first, dict):
+            compare_nested_dicts(_first, _second)
 
-        elif isinstance(first[key], (list, np.ndarray, tuple)):
-            compare_nested_iterables(first[key], second[key])
+        elif isinstance(_first, (list, np.ndarray, tuple)):
+            compare_nested_iterables(_first, _second)
 
-        elif isinstance(first[key], pd.DataFrame):
-            assert first[key].equals(second[key])
+        elif isinstance(_first, pd.DataFrame):
+            assert _first.equals(_second)
 
-        elif isinstance(first[key], float):
-            assert compare_values_epsilon(first[key], second[key], key)
+        elif isinstance(_first, float):
+            message = COMPARE_VALUES_ERROR.format(key, _first, _second)
+            assert compare_values_epsilon(_first, _second), message
 
         else:
-            assert first[key] == second[key], "{} doesn't equal {}".format(first[key], second[key])
+            assert _first == _second, "{} doesn't equal {}".format(_first, _second)
 
 
-def compare_values_epsilon(first, second, index=None, epsilon=10E-6,):
-    return abs(first - second) < epsilon, COMPARE_VALUES_ERROR.format(index, first, second)
+def compare_values_epsilon(first, second, epsilon=10E-6,):
+    if pd.isnull(first) and pd.isnull(second):
+        return True
+
+    return abs(first - second) < epsilon
 
 
 def compare_nested_iterables(first, second, epsilon=10E-6):
@@ -43,7 +48,8 @@ def compare_nested_iterables(first, second, epsilon=10E-6):
             compare_nested_dicts(_first, _second)
 
         elif isinstance(_first, float):
-            assert compare_values_epsilon(_first, _second)
+            message = COMPARE_VALUES_ERROR.format(index, _first, _second)
+            assert compare_values_epsilon(_first, _second), message
 
         else:
             assert _first == _second, COMPARE_VALUES_ERROR.format(index, _first, _second)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,7 @@ import pandas as pd
 COMPARE_VALUES_ERROR = 'Values don\'t match at index {}\n {} != {}'
 NUMPY_NUMERICAL_DTYPES = set('buifc')
 
+
 def compare_nested_dicts(first, second, epsilon=10E-6):
     """Compares two dictionaries. Raises an assertion error when a difference is found."""
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pandas as pd
 
+COMPARE_VALUES_ERROR = 'Values don\'t match at index {}\n {} != {}'
+
 
 def compare_nested_dicts(first, second, epsilon=10E-6):
     """Compares two dictionaries. Raises an assertion error when a difference is found."""
@@ -11,32 +13,37 @@ def compare_nested_dicts(first, second, epsilon=10E-6):
         if isinstance(first[key], dict):
             compare_nested_dicts(first[key], second[key])
 
-        elif isinstance(first[key], np.ndarray):
-            assert (compare_values_epsilon(first[key], second[key])).all()
+        elif isinstance(first[key], (list, np.ndarray, tuple)):
+            compare_nested_iterables(first[key], second[key])
 
         elif isinstance(first[key], pd.DataFrame):
             assert first[key].equals(second[key])
 
         elif isinstance(first[key], float):
-            assert compare_values_epsilon(first[key], second[key])
-
-        elif isinstance(first[key], list):
-            compare_nested_iterables(first[key], second[key])
+            assert compare_values_epsilon(first[key], second[key], key)
 
         else:
             assert first[key] == second[key], "{} doesn't equal {}".format(first[key], second[key])
 
 
-def compare_values_epsilon(first, second, epsilon=10E-6):
-    return abs(first - second) < epsilon
+def compare_values_epsilon(first, second, index=None, epsilon=10E-6,):
+    return abs(first - second) < epsilon, COMPARE_VALUES_ERROR.format(index, first, second)
 
 
 def compare_nested_iterables(first, second, epsilon=10E-6):
 
-    for _first, _second in zip(first, second):
+    assert len(first) == len(second), "Iterables should have the same length to be compared."
 
-        if isinstance(_first, list):
+    for index, (_first, _second) in enumerate(zip(first, second)):
+
+        if isinstance(_first, (list, np.ndarray, tuple)):
             compare_nested_iterables(_first, _second)
 
-        if isinstance(_first, float):
+        elif isinstance(_first, dict):
+            compare_nested_dicts(_first, _second)
+
+        elif isinstance(_first, float):
             assert compare_values_epsilon(_first, _second)
+
+        else:
+            assert _first == _second, COMPARE_VALUES_ERROR.format(index, _first, _second)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 COMPARE_VALUES_ERROR = 'Values don\'t match at index {}\n {} != {}'
-
+NUMPY_NUMERICAL_DTYPES = set('buifc')
 
 def compare_nested_dicts(first, second, epsilon=10E-6):
     """Compares two dictionaries. Raises an assertion error when a difference is found."""
@@ -46,8 +46,11 @@ def compare_nested_iterables(first, second, epsilon=10E-6):
         if isinstance(_first, (list, tuple)):
             compare_nested_iterables(_first, _second, epsilon)
 
-        if isinstance(_first, np.ndarray):
-            np.testing.assert_equal(_first, _second)
+        elif isinstance(_first, np.ndarray):
+            if _first.dtype.kind in NUMPY_NUMERICAL_DTYPES:
+                np.testing.assert_allclose(_first, _second)
+            else:
+                compare_nested_iterables(_first, _second, epsilon)
 
         elif isinstance(_first, dict):
             compare_nested_dicts(_first, _second, epsilon)
@@ -57,7 +60,6 @@ def compare_nested_iterables(first, second, epsilon=10E-6):
 
         else:
             assert _first == _second, message
-
 
 
 def copula_zero_if_arg_zero(copula, dimensions=2, steps=10, tolerance=1E-05):

--- a/tests/copulas/multivariate/test_tree.py
+++ b/tests/copulas/multivariate/test_tree.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -6,12 +7,13 @@ import pandas as pd
 from copulas.bivariate import CopulaTypes
 from copulas.multivariate.tree import Edge, Tree, TreeTypes
 from copulas.univariate.kde import KDEUnivariate
-from tests import compare_nested_dicts
+from tests import compare_nested_dicts, compare_nested_iterables
 
 
 class TestTree(TestCase):
 
     def test_to_dict_unfitted_model(self):
+        """to_dict returns a simpler dict when Tree is not fitted."""
         # Setup
         instance = Tree(TreeTypes.REGULAR)
         expected_result = {
@@ -63,6 +65,7 @@ class TestTree(TestCase):
             'tree_type': TreeTypes.REGULAR,
             'edges': [
                 {
+                    'index': 0,
                     'D': set(),
                     'L': 0,
                     'R': 1,
@@ -78,6 +81,7 @@ class TestTree(TestCase):
                     'theta': -5.736282443655552
                 },
                 {
+                    'index': 1,
                     'D': set(),
                     'L': 1,
                     'R': 2,
@@ -308,6 +312,18 @@ class TestDirectTree(TestCase):
         assert self.tree.edges[0].neighbors == [1]
         assert self.tree.edges[1].neighbors == [0, 2]
 
+    def test_get_tau_matrix_no_edges_empty(self):
+        """get_tau_matrix returns an empty array if there are no edges."""
+        # Setup
+        tree = Tree(TreeTypes.DIRECT)
+        tree.edges = []
+
+        # Run
+        result = tree.get_tau_matrix()
+
+        # Check
+        assert result.shape == (0, 0)
+
     def test_get_tau_matrix(self):
         """ Assert none of get tau matrix is NaN """
         self.tau = self.tree.get_tau_matrix()
@@ -340,15 +356,105 @@ class TestEdge(TestCase):
         self.e2.D = [1, 5]
 
     def test_identify_eds(self):
-        left, right, depend_set = Edge._identify_eds_ing(self.e1, self.e2)
-        assert left == 2
-        assert right == 4
-        expected_result = set([1, 3, 5])
-        assert depend_set == expected_result
+        """_identify_eds_ing returns the left, right and dependency for a new edge."""
+        # Setup
+        first = Edge(None, 2, 5, None, None)
+        first.D = {1, 3}
+
+        second = Edge(None, 3, 4, None, None)
+        second.D = {1, 5}
+
+        # Please, note that we passed the index, copula_name and copula_theta as None
+        # To show they are no going to be used in the scope of this test.
+
+        # left, right and dependence set
+        expected_result = (2, 4, set([1, 3, 5]))
+
+        # Run
+        result = Edge._identify_eds_ing(first, second)
+
+        # Check
+        assert result == expected_result
+
+    def test_identify_eds_empty_dependence(self):
+        """_identify_eds_ing don't require edges to have dependence set."""
+        # Setup
+        first = Edge(None, 0, 1, None, None)
+        second = Edge(None, 1, 2, None, None)
+
+        # Please, note that we passed the index, copula_name and copula_theta as None
+        # To show they are no going to be used in the scope of this test.
+
+        # left, right and dependence set
+        expected_result = (0, 2, {1})
+
+        # Run
+        result = Edge._identify_eds_ing(first, second)
+
+        # Check
+        assert result == expected_result
+
+    def test_identify_eds_not_adjacent(self):
+        """_identify_eds_ing raises a ValueError if the edges are not adjacent."""
+        # Setup
+        first = Edge(None, 0, 1, None, None)
+        second = Edge(None, 2, 3, None, None)
+
+        # Please, note that we passed the index, copula_name and copula_theta as None
+        # To show they are no going to be used in the scope of this test.
+
+        # Run / Check
+        # As they are not adjacent, we can asure calling _identify_eds_ing will raise a ValueError.
+        assert not first.is_adjacent(second)
+
+        with self.assertRaises(ValueError):
+            Edge._identify_eds_ing(first, second)
+
+    @patch('copulas.multivariate.tree.Edge._identify_eds_ing')
+    def test_get_conditional_uni(self, adjacent_mock):
+        """get_conditional_uni return the corresponding univariate adjacent to the parents."""
+        # Setup
+        left = Edge(None, 1, 2, None, None)
+        left.U = np.array([
+            ['left_0_0', 'left_0_1'],
+            ['left_1_0', 'left_1_1']
+        ])
+
+        right = Edge(None, 4, 2, None, None)
+        right.U = np.array([
+            ['right_0_0', 'right_0_1'],
+            ['right_1_0', 'right_1_1']
+        ])
+
+        adjacent_mock.return_value = (0, 1, None)
+        expected_result = (
+            np.array(['left_1_0', 'left_1_1']),
+            np.array(['right_1_0', 'right_1_1'])
+        )
+
+        # Run
+        result = Edge.get_conditional_uni(left, right)
+
+        # Check
+        compare_nested_iterables(result, expected_result)
 
     def test_sort_edge(self):
-        sorted_edges = Edge.sort_edge([self.e2, self.e1])
-        assert sorted_edges[0].L == 2
+        """sort_edge sorts Edge objects by left node index, and in case of match by right index."""
+        # Setup
+        edge_1 = Edge(None, 1, 0, None, None)
+        edge_2 = Edge(None, 1, 1, None, None)
+        edge_3 = Edge(None, 1, 2, None, None)
+        edge_4 = Edge(None, 2, 0, None, None)
+        edge_5 = Edge(None, 3, 0, None, None)
+
+        edges = [edge_3, edge_1, edge_5, edge_4, edge_2]
+        expected_result = [edge_1, edge_2, edge_3, edge_4, edge_5]
+
+        # Run
+        result = Edge.sort_edge(edges)
+
+        # Check
+        assert result == expected_result
 
     def test_to_dict(self):
         """To_dict returns a dictionary with the parameters to recreate an edge."""
@@ -415,3 +521,116 @@ class TestEdge(TestCase):
 
         # Check
         assert instance.to_dict() == result.to_dict()
+
+    @patch('copulas.multivariate.tree.Bivariate', autospec=True)
+    def test_get_likelihood_no_parents(self, bivariate_mock):
+        """get_likelihood will use current node indices if there are no parents."""
+        # Setup
+        index = 0
+        left = 0
+        right = 1
+        copula_name = 'copula_name'
+        copula_theta = 'copula_theta'
+        instance = Edge(index, left, right, copula_name, copula_theta)
+
+        univariates = np.array([
+            [0.25, 0.75],
+            [0.50, 0.50],
+            [0.75, 0.25]
+        ]).T
+
+        instance_mock = bivariate_mock.return_value
+        instance_mock.probability_density.return_value = [0]
+        instance_mock.partial_derivative.return_value = 'partial_derivative'
+
+        expected_partial_derivative_call_args = [
+            (
+                (np.array([[
+                    [0.25, 0.75],
+                    [0.50, 0.50],
+                ]]),), {}
+            ),
+            (
+                (np.array([[
+                    [0.50, 0.50],
+                    [0.25, 0.75]
+                ]]), ), {}
+            )
+        ]
+
+        # Run
+        result = instance.get_likelihood(univariates)
+
+        # Check
+        value, left_given_right, right_given_left = result
+        assert value == 0
+        assert left_given_right == 'partial_derivative'
+        assert right_given_left == 'partial_derivative'
+
+        bivariate_mock.assert_called_once_with('copula_name')
+
+        assert instance_mock.theta == 'copula_theta'
+        compare_nested_iterables(
+            instance_mock.partial_derivative.call_args_list,
+            expected_partial_derivative_call_args
+        )
+
+    @patch('copulas.multivariate.tree.Bivariate', autospec=True)
+    def test_get_likelihood_with_parents(self, bivariate_mock):
+        """If edge has parents, their dependences are used to retrieve univariates."""
+        # Setup
+        index = None
+        left = 0
+        right = 1
+        copula_name = 'copula_name'
+        copula_theta = 'copula_theta'
+        instance = Edge(index, left, right, copula_name, copula_theta)
+        instance.D = {0, 1, 2, 3}
+
+        parent_1 = MagicMock(spec=Edge)
+        parent_1.D = {1, 2, 3}
+
+        parent_2 = MagicMock(spec=Edge)
+        parent_2.D = {0, 2, 3}
+
+        univariates = np.array([
+            [0.25, 0.75],
+            [0.50, 0.50],
+            [0.75, 0.25]
+        ]).T
+
+        instance_mock = bivariate_mock.return_value
+        instance_mock.probability_density.return_value = [0]
+        instance_mock.partial_derivative.return_value = 'partial_derivative'
+
+        expected_partial_derivative_call_args = [
+            (
+                (np.array([[
+                    [0.25, 0.75],
+                    [0.50, 0.50],
+                ]]),), {}
+            ),
+            (
+                (np.array([[
+                    [0.50, 0.50],
+                    [0.25, 0.75]
+                ]]), ), {}
+            )
+        ]
+
+        # Run
+        result = instance.get_likelihood(univariates)
+
+        # Check
+        value, left_given_right, right_given_left = result
+        assert value == 0
+        assert left_given_right == 'partial_derivative'
+        assert right_given_left == 'partial_derivative'
+
+        bivariate_mock.assert_called_once_with('copula_name')
+
+        assert instance_mock.theta == 'copula_theta'
+        compare_nested_iterables(
+            instance_mock.partial_derivative.call_args_list,
+            expected_partial_derivative_call_args
+        )

--- a/tests/copulas/multivariate/test_vine.py
+++ b/tests/copulas/multivariate/test_vine.py
@@ -53,7 +53,7 @@ class TestVine(TestCase):
 
         # FIX ME: there is some randomness in rvine, will do another test
         rvalue = self.rvine.get_likelihood(uni_matrix)
-        expected = -0.2859820599667698
+        expected = -0.26888124854583245
         assert abs(rvalue - expected) < 10E-3
 
         cvalue = self.cvine.get_likelihood(uni_matrix)

--- a/tests/copulas/test___init__.py
+++ b/tests/copulas/test___init__.py
@@ -68,6 +68,7 @@ class TestCheckValidValues(TestCase):
         function_mock.assert_not_called()
         instance_mock.assert_not_called()
 
+
 class TestRandomStateDecorator(TestCase):
 
     @patch('copulas.np.random')

--- a/tests/copulas/test___init__.py
+++ b/tests/copulas/test___init__.py
@@ -1,0 +1,69 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from copulas import check_valid_values
+
+
+class TestCheckValidValues(TestCase):
+
+    def test_check_valid_values_raises_valuerror_if_nans(self):
+        """check_valid_values raises a ValueError if is given data with nans."""
+        # Setup
+        X = np.array([
+            [1.0, np.nan],
+            [0.0, 1.0]
+        ])
+
+        instance_mock = MagicMock()
+        function_mock = MagicMock()
+
+        # Run
+        decorated_function = check_valid_values(function_mock)
+
+        # Check:
+        with self.assertRaises(ValueError):
+            decorated_function(instance_mock, X)
+
+        function_mock.assert_not_called()
+        instance_mock.assert_not_called()
+
+    def test_check_valid_values_raises_valueerror_if_not_numeric(self):
+        """check_valid_values raises a ValueError if is given data with non numeric values."""
+        # Setup
+        X = np.array([
+            [1.0, 'A'],
+            [0.0, 1.0]
+        ])
+
+        instance_mock = MagicMock()
+        function_mock = MagicMock()
+
+        # Run
+        decorated_function = check_valid_values(function_mock)
+
+        # Check:
+        with self.assertRaises(ValueError):
+            decorated_function(instance_mock, X)
+
+        function_mock.assert_not_called()
+        instance_mock.assert_not_called()
+
+    def test_check_valid_values_raises_valueerror_empty_dataset(self):
+        """check_valid_values raises a ValueError if given data is empty."""
+        # Setup
+        X = np.array([])
+
+        instance_mock = MagicMock()
+        function_mock = MagicMock()
+
+        # Run
+        decorated_function = check_valid_values(function_mock)
+
+        # Check:
+        with self.assertRaises(ValueError):
+            decorated_function(instance_mock, X)
+
+        function_mock.assert_not_called()
+        instance_mock.assert_not_called()

--- a/tests/copulas/univariate/test_gaussian.py
+++ b/tests/copulas/univariate/test_gaussian.py
@@ -56,23 +56,12 @@ class TestGaussianUnivariate(TestCase):
         assert copula.name == name
         assert copula.fitted
 
-    def test_fit_empty_data(self):
-        """On fit, if column is empty an error is raised."""
-
-        # Setup
-        copula = GaussianUnivariate()
-        column = pd.Series([])
-
-        # Run
-        with self.assertRaises(ValueError):
-            copula.fit(column)
-
     def test_test_fit_equal_values(self):
         """On fit, even if column has equal values, std is never 0."""
 
         # Setup
         copula = GaussianUnivariate()
-        column = [1, 1, 1, 1, 1, 1]
+        column = np.array([1, 1, 1, 1, 1, 1])
 
         # Run
         copula.fit(column)
@@ -86,7 +75,7 @@ class TestGaussianUnivariate(TestCase):
 
         # Setup
         copula = GaussianUnivariate()
-        column = [-1, 0, 1]
+        column = np.array([-1, 0, 1])
         copula.fit(column)
         expected_result = 0.48860251190292
 
@@ -101,7 +90,7 @@ class TestGaussianUnivariate(TestCase):
 
         # Setup
         copula = GaussianUnivariate()
-        column = [-1, 0, 1]
+        column = np.array([-1, 0, 1])
         copula.fit(column)
         x = pd.Series([0])
         expected_result = [0.5]
@@ -117,7 +106,7 @@ class TestGaussianUnivariate(TestCase):
 
         # Setup
         copula = GaussianUnivariate()
-        column = [-1, 0, 1]
+        column = np.array([-1, 0, 1])
         copula.fit(column)
         x = 0.5
         expected_result = 0
@@ -133,7 +122,7 @@ class TestGaussianUnivariate(TestCase):
 
         # Setup
         copula = GaussianUnivariate()
-        column = [-1, 0, 1]
+        column = np.array([-1, 0, 1])
         copula.fit(column)
         initial_value = pd.Series([0])
 
@@ -149,7 +138,7 @@ class TestGaussianUnivariate(TestCase):
         """After fitting, GaussianUnivariate is able to sample new data."""
         # Setup
         copula = GaussianUnivariate()
-        column = [-1, 0, 1]
+        column = np.array([-1, 0, 1])
         copula.fit(column)
 
         # Run
@@ -164,7 +153,7 @@ class TestGaussianUnivariate(TestCase):
         """To_dict returns the defining parameters of a distribution in a dict."""
         # Setup
         copula = GaussianUnivariate()
-        column = [0, 1, 2, 3, 4, 5]
+        column = np.array([0, 1, 2, 3, 4, 5])
         copula.fit(column)
         expected_result = {
             'type': 'copulas.univariate.gaussian.GaussianUnivariate',

--- a/tests/copulas/univariate/test_kde.py
+++ b/tests/copulas/univariate/test_kde.py
@@ -29,7 +29,7 @@ class TestKDEUnivariate(TestCase):
     def test_fit(self):
         """On fit, kde model is instantiated with intance of gaussian_kde."""
         self.kde = KDEUnivariate()
-        data = [1, 2, 3, 4, 5]
+        data = np.array([1, 2, 3, 4, 5])
 
         self.kde.fit(data)
 
@@ -38,18 +38,11 @@ class TestKDEUnivariate(TestCase):
     def test_fit_uniform(self):
         """On fit, kde model is instantiated with passed data."""
         self.kde = KDEUnivariate()
-        data = [1, 2, 3, 4, 5]
+        data = np.array([1, 2, 3, 4, 5])
 
         self.kde.fit(data)
 
         assert self.kde.model
-
-    def test_fit_empty_data(self):
-        """If fitting kde model with empty data it will raise ValueError."""
-        self.kde = KDEUnivariate()
-
-        with self.assertRaises(ValueError):
-            self.kde.fit([])
 
     def test_probability_density(self):
         """probability_density evaluates with the model."""


### PR DESCRIPTION
On this pull requests contains the changes made in order to resolve the bug that caused a crash on `VineCopulas` when fitting with the `breast_cancer` dataset. This changes include:

- A decorator to check for invalid data on fit time for all models and distributions.
- Stricter testing helper functions.
- Added / Refactored some tests of the Edge and Tree classes.
- Found and fix the original cause of the bug: On `Tree.prepare_next_tree` the copula was being fit with conditional data, but it should have used the theta computed in the Edge.

Resolves #64