### PR TITLE
Issue 61: Tests for analytic properties of copulas

### DIFF
--- a/copulas/bivariate/clayton.py
+++ b/copulas/bivariate/clayton.py
@@ -56,7 +56,7 @@ class Clayton(Bivariate):
                     np.power(U[i], -self.theta) + np.power(V[i], -self.theta) - 1,
                     -1.0 / self.theta
                 )
-                if U[i] > 0 else 0
+                if (U[i] > 0 and V[i] > 0) else 0
                 for i in range(len(U))
             ]
 

--- a/copulas/bivariate/gumbel.py
+++ b/copulas/bivariate/gumbel.py
@@ -109,9 +109,4 @@ class Gumbel(Bivariate):
         On Gumbel copula :math:`\\tau is defined as :math:`τ = \\frac{θ−1}{θ}`
         that we solve as :math:`θ = \\frac{1}{1-τ}`
         """
-        if self.tau == 1:
-            theta = 10000
-        else:
-            theta = 1 / (1 - self.tau)
-
-        return theta
+        return 1 / (1 - self.tau)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -36,7 +36,81 @@ def compare_nested_iterables(first, second, epsilon=10E-6):
     for _first, _second in zip(first, second):
 
         if isinstance(_first, list):
-            compare_nested_iterables(_first, _second)
+            compare_nested_iterables(_first, _second, epsilon)
 
         if isinstance(_first, float):
-            assert compare_values_epsilon(_first, _second)
+            assert compare_values_epsilon(_first, _second, epsilon)
+
+
+def copula_zero_if_arg_zero(copula, dimensions=2, steps=10, tolerance=1E-05):
+    """Assert that any call with an argument equal to 0, will return 0.
+
+    This function helps to test the following analytical property of copulas:
+    If C is a copula and (u0, ..., uN) is in [0, 1]^N
+
+    C(u0, ..., uM-1, 0, uM+1, ..., uN) = 0 for any 0 < M < N
+
+    Args:
+        copula(Bivariate or Multivariate): Copula instance to test.
+        dimensions(int): Number of dimensions supported by given copulas.
+        steps(int): Number of partitions of [0,1] to use to generate values.
+        tolerance(float): Maximum difference in absolute value before raising error.
+
+    Raises:
+        AssertionError: If any value doesn't comply with the expected behavior.
+    """
+    # Setup
+    step_values = np.linspace(0.0, 1.0, steps + 1)[1:]
+    values = []
+
+    for index in range(dimensions):
+        for value in step_values:
+            result = np.full(dimensions, value)
+            result[index] = 0
+            values.append(result.tolist())
+
+    probabilities = np.array(values)
+    expected_result = np.zeros(dimensions * steps)
+
+    # Run
+    result = copula.cdf(probabilities)
+
+    # Check
+    compare_nested_iterables(result, expected_result, tolerance)
+
+
+def copula_single_arg_not_one(copula, dimensions=2, steps=10, tolerance=1E-05):
+    """Assert that any call where all arguments minus one are 1, will return the non-1 value.
+
+    This functions helps to test the following analytic property of copulas:
+    If C is a copula and (u0, ..., uN) is in [0, 1]^N
+
+    C(1, ..., 1, uM, 1, ..., 1) = uM for any 0 < M < N
+
+    Args:
+        copula(Bivariate or Multivariate): Copula instance to test
+        dimensions(int): Number of dimensions supported by given copulas.
+        steps(int): Number of partitions of [0,1] to use to generate values.
+        tolerance(float): Maximum difference in absolute value before raising error.
+
+    Raises:
+        AssertionError: If any value doesn't comply with the expected behavior.
+    """
+    # Setup
+    step_values = np.linspace(0.0, 1.0, steps + 1)[1: -1]
+    values = []
+
+    for index in range(dimensions):
+        for value in step_values:
+            result = np.ones(dimensions)
+            result[index] = value
+            values.append(result.tolist())
+
+    probabilities = np.array(values)
+    expected_result = np.tile(step_values, dimensions)
+
+    # Run
+    result = copula.cdf(probabilities)
+
+    # Check
+    compare_nested_iterables(result, expected_result, tolerance)

--- a/tests/copulas/bivariate/test_clayton.py
+++ b/tests/copulas/bivariate/test_clayton.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 import numpy as np
 
 from copulas.bivariate.base import Bivariate, CopulaTypes
+from tests import copula_single_arg_not_one, copula_zero_if_arg_zero
 
 
 class TestClayton(TestCase):
@@ -107,3 +108,27 @@ class TestClayton(TestCase):
         # Check
         assert isinstance(result, np.ndarray)
         assert result.shape == (10, 2)
+
+    def test_cdf_zero_if_single_arg_is_zero(self):
+        """Test of the analytical properties of copulas on a range of values of theta."""
+        # Setup
+        instance = Bivariate(CopulaTypes.CLAYTON)
+        tau_values = np.linspace(-1.0, 1.0, 20)[1: -1]
+
+        # Run/Check
+        for tau in tau_values:
+            instance.tau = tau
+            instance.theta = instance.compute_theta()
+            copula_zero_if_arg_zero(instance)
+
+    def test_cdf_value_if_all_other_arg_are_one(self):
+        """Test of the analytical properties of copulas on a range of values of theta."""
+        # Setup
+        instance = Bivariate(CopulaTypes.CLAYTON)
+        tau_values = np.linspace(-1.0, 1.0, 20)[1: -1]
+
+        # Run/Check
+        for tau in tau_values:
+            instance.tau = tau
+            instance.theta = instance.compute_theta()
+            copula_single_arg_not_one(instance)

--- a/tests/copulas/bivariate/test_frank.py
+++ b/tests/copulas/bivariate/test_frank.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 import numpy as np
 
 from copulas.bivariate.base import Bivariate, CopulaTypes
+from tests import copula_single_arg_not_one, copula_zero_if_arg_zero
 
 
 class TestFrank(TestCase):
@@ -88,3 +89,27 @@ class TestFrank(TestCase):
         # Check
         assert isinstance(result, np.ndarray)
         assert result.shape == (10, 2)
+
+    def test_cdf_zero_if_single_arg_is_zero(self):
+        """Test of the analytical properties of copulas on a range of values of theta."""
+        # Setup
+        instance = Bivariate(CopulaTypes.FRANK)
+        tau_values = np.linspace(-1.0, 1.0, 20)[1: -1]
+
+        # Run/Check
+        for tau in tau_values:
+            instance.tau = tau
+            instance.theta = instance.compute_theta()
+            copula_zero_if_arg_zero(instance)
+
+    def test_cdf_value_if_all_other_arg_are_one(self):
+        """Test of the analytical properties of copulas on a range of values of theta."""
+        # Setup
+        instance = Bivariate(CopulaTypes.FRANK)
+        tau_values = np.linspace(-1.0, 1.0, 20)[1: -1]
+
+        # Run/Check
+        for tau in tau_values:
+            instance.tau = tau
+            instance.theta = instance.compute_theta()
+            copula_single_arg_not_one(instance, tolerance=1E-03)

--- a/tests/copulas/bivariate/test_gumbel.py
+++ b/tests/copulas/bivariate/test_gumbel.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 import numpy as np
 
 from copulas.bivariate.base import Bivariate, CopulaTypes
+from tests import copula_single_arg_not_one, copula_zero_if_arg_zero
 
 
 class TestGumbel(TestCase):
@@ -90,3 +91,27 @@ class TestGumbel(TestCase):
         # Check
         assert isinstance(result, np.ndarray)
         assert result.shape == (10, 2)
+
+    def test_cdf_zero_if_single_arg_is_zero(self):
+        """Test of the analytical properties of copulas on a range of values of theta."""
+        # Setup
+        instance = Bivariate(CopulaTypes.GUMBEL)
+        tau_values = np.linspace(0.0, 1.0, 20)[1: -1]
+
+        # Run/Check
+        for tau in tau_values:
+            instance.tau = tau
+            instance.theta = instance.compute_theta()
+            copula_zero_if_arg_zero(instance)
+
+    def test_cdf_value_if_all_other_arg_are_one(self):
+        """Test of the analytical properties of copulas on a range of values of theta."""
+        # Setup
+        instance = Bivariate(CopulaTypes.GUMBEL)
+        tau_values = np.linspace(0.0, 1.0, 20)[1: -1]
+
+        # Run/Check
+        for tau in tau_values:
+            instance.tau = tau
+            instance.theta = instance.compute_theta()
+            copula_single_arg_not_one(instance)


### PR DESCRIPTION
Add testing helper functions to check for the analytical properties of copulas and use add unit tests using them on `Bivariate` copulas with a range of values of theta, computed from partitions of the interval of possible values of tau [-1, 1].

Resolves #61 