### PR TITLE
Issue 99: Remove constant_value key in distribution serialization

### DIFF
--- a/copulas/univariate/base.py
+++ b/copulas/univariate/base.py
@@ -259,8 +259,8 @@ class ScipyWrapper(Univariate):
     sample = None
     METHOD_NAMES = ('sample', 'probability_density', 'cumulative_distribution', 'percent_point')
 
-    def __init__(self):
-        super(ScipyWrapper, self).__init__()
+    def __init__(self, *args, **kwargs):
+        super(ScipyWrapper, self).__init__(*args, **kwargs)
 
     @check_valid_values
     def fit(self, X, *args, **kwargs):

--- a/copulas/univariate/base.py
+++ b/copulas/univariate/base.py
@@ -83,7 +83,6 @@ class Univariate(object):
         result = {
             'type': get_qualified_name(self),
             'fitted': self.fitted,
-            'constant_value': self.constant_value
         }
 
         if not self.fitted:

--- a/copulas/univariate/gaussian.py
+++ b/copulas/univariate/gaussian.py
@@ -18,8 +18,8 @@ class GaussianUnivariate(Univariate):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.name = None
-        self.mean = 0
-        self.std = 1
+        self.mean = None
+        self.std = None
 
     def __str__(self):
         details = [self.name, self.mean, self.std]
@@ -104,6 +104,12 @@ class GaussianUnivariate(Univariate):
         return np.random.normal(self.mean, self.std, num_samples)
 
     def _fit_params(self):
+        if self.constant_value is not None:
+            return {
+                'mean': self.constant_value,
+                'std': 0
+            }
+
         return {
             'mean': self.mean,
             'std': self.std,
@@ -114,10 +120,16 @@ class GaussianUnivariate(Univariate):
         """Set attributes with provided values."""
         instance = cls()
         instance.fitted = copula_dict['fitted']
-        instance.constant_value = copula_dict['constant_value']
 
-        if instance.fitted and instance.constant_value is None:
+        if not instance.fitted:
+            return instance
+
+        std = copula_dict['std']
+        if std == 0:
+            instance.constant_value = copula_dict['mean']
+
+        else:
             instance.mean = copula_dict['mean']
-            instance.std = copula_dict['std']
+            instance.std = std
 
         return instance

--- a/copulas/univariate/gaussian_kde.py
+++ b/copulas/univariate/gaussian_kde.py
@@ -12,6 +12,10 @@ class GaussianKDE(ScipyWrapper):
     in scipy.stats toolbox. gaussian_kde is slower than statsmodels
     but allows more flexibility.
 
+    When a sample_size is provided the fit method will sample the
+    data, and mask the real information. Also, ensure the number of
+    entries will be always the value of sample_size.
+
     Args:
         sample_size(int): amount of parameters to sample
     """

--- a/copulas/univariate/gaussian_kde.py
+++ b/copulas/univariate/gaussian_kde.py
@@ -11,6 +11,9 @@ class GaussianKDE(ScipyWrapper):
     """A wrapper for gaussian Kernel density estimation implemented
     in scipy.stats toolbox. gaussian_kde is slower than statsmodels
     but allows more flexibility.
+
+    Args:
+        sample_size(int): amount of parameters to sample
     """
 
     model_class = 'gaussian_kde'
@@ -25,9 +28,9 @@ class GaussianKDE(ScipyWrapper):
         self.constant_value = self._get_constant_value(X)
 
         if self.constant_value is None:
-            if self.sample_size is not None:
-                model = scipy.stats.gaussian_kde(X)
-                X = model.resample(self.sample_size)
+            if self.sample_size:
+                X = self.sample(self.sample_size)
+                super().fit(X, *args, **kwargs)
 
             super().fit(X, *args, **kwargs)
 

--- a/copulas/univariate/gaussian_kde.py
+++ b/copulas/univariate/gaussian_kde.py
@@ -17,7 +17,6 @@ class GaussianKDE(ScipyWrapper):
     probability_density = 'evaluate'
     sample = 'resample'
 
-
     def __init__(self, sample_size=None, *args, **kwargs):
         self.sample_size = sample_size
         super().__init__(*args, **kwargs)
@@ -26,12 +25,11 @@ class GaussianKDE(ScipyWrapper):
         self.constant_value = self._get_constant_value(X)
 
         if self.constant_value is None:
-            model = scipy.stats.gaussian_kde(X)
-            if self.sample_size is None:
-                self.sample_size = max(X.shape)
+            if self.sample_size is not None:
+                model = scipy.stats.gaussian_kde(X)
+                X = model.resample(self.sample_size)
 
-            samples = model.resample(self.sample_size)
-            super().fit(samples, *args, **kwargs)
+            super().fit(X, *args, **kwargs)
 
         else:
             self._replace_constant_methods()

--- a/copulas/univariate/kde.py
+++ b/copulas/univariate/kde.py
@@ -104,21 +104,37 @@ class KDEUnivariate(Univariate):
         instance = cls()
 
         instance.fitted = copula_dict['fitted']
-        instance.constant_value = copula_dict['constant_value']
 
-        if instance.fitted and not instance.constant_value:
-            instance.model = scipy.stats.gaussian_kde([-1, 0, 0])
+        if instance.fitted:
 
-            for key in ['dataset', 'covariance', 'inv_cov']:
-                copula_dict[key] = np.array(copula_dict[key])
+            covariance = copula_dict['covariance']
+            if not isinstance(covariance, list):
+                instance.constant_value = covariance
 
-            attributes = ['d', 'n', 'dataset', 'covariance', 'factor', 'inv_cov']
-            for name in attributes:
-                setattr(instance.model, name, copula_dict[name])
+            if instance.constant_value is None:
+                instance.model = scipy.stats.gaussian_kde([-1, 0, 0])
+
+                copula_dict['covariance'] = np.array(covariance)
+                for key in ['dataset', 'inv_cov']:
+                    copula_dict[key] = np.array(copula_dict[key])
+
+                attributes = ['d', 'n', 'dataset', 'covariance', 'factor', 'inv_cov']
+                for name in attributes:
+                    setattr(instance.model, name, copula_dict[name])
 
         return instance
 
     def _fit_params(self):
+        if self.constant_value is not None:
+            return {
+                'd': 0,
+                'n': 0,
+                'dataset': [],
+                'covariance': self.constant_value,
+                'factor': 0,
+                'inv_cov': []
+            }
+
         return {
             'd': self.model.d,
             'n': self.model.n,

--- a/copulas/univariate/kde.py
+++ b/copulas/univariate/kde.py
@@ -11,7 +11,7 @@ class KDEUnivariate(Univariate):
     but allows more flexibility.
     """
 
-    def __init__(self, sample_size=10, *args, **kwargs):
+    def __init__(self, sample_size=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.sample_size = sample_size
         self.model = None
@@ -30,9 +30,11 @@ class KDEUnivariate(Univariate):
         self.constant_value = self._get_constant_value(X)
 
         if self.constant_value is None:
-            model = scipy.stats.gaussian_kde(X)
-            sample = model.resample(self.sample_size)
-            self.model = scipy.stats.gaussian_kde(sample)
+            if self.sample_size is not None:
+                model = scipy.stats.gaussian_kde(X)
+                X = model.resample(self.sample_size)
+
+            self.model = scipy.stats.gaussian_kde(X)
 
         else:
             self._replace_constant_methods()

--- a/copulas/univariate/truncnorm.py
+++ b/copulas/univariate/truncnorm.py
@@ -21,8 +21,6 @@ class TruncNorm(ScipyWrapper):
         """Prepare necessary params and call super().fit."""
         min_ = X.min() - EPSILON
         max_ = X.max() + EPSILON
-        self.mean = X.mean()
-        self.std = X.std()
 
         super().fit(X, min_, max_)
 
@@ -38,10 +36,16 @@ class TruncNorm(ScipyWrapper):
         """
         instance = cls()
         instance.fitted = parameters['fitted']
-        instance.constant_value = parameters['constant_value']
 
-        if instance.fitted and instance.constant_value is None:
-            instance.model = scipy.stats.truncnorm(parameters['a'], parameters['b'])
+        if instance.fitted:
+            a = parameters['a']
+            b = parameters['b']
+
+            if a > b:
+                instance.constant_value = a
+
+            else:
+                instance.model = scipy.stats.truncnorm(a, b)
 
         return instance
 
@@ -51,6 +55,12 @@ class TruncNorm(ScipyWrapper):
         Returns:
             dict: Parameters to recreate self.model in its current fit status.
         """
+        if self.constant_value is not None:
+            return {
+                'a': self.constant_value,
+                'b': self.constant_value - 1
+            }
+
         return {
             'a': self.model.a,
             'b': self.model.b

--- a/copulas/univariate/truncnorm.py
+++ b/copulas/univariate/truncnorm.py
@@ -23,10 +23,8 @@ class TruncNorm(ScipyWrapper):
         if self.constant_value is None:
             min_ = X.min() - EPSILON
             max_ = X.max() + EPSILON
-            mean = X.mean()
-            std = X.std()
 
-            super().fit(X, min_, max_, loc=mean, scale=std)
+            super().fit(X, min_, max_)
         else:
             self._replace_constant_methods()
 
@@ -48,14 +46,12 @@ class TruncNorm(ScipyWrapper):
         if instance.fitted:
             a = parameters['a']
             b = parameters['b']
-            mean = parameters['mean']
-            std = parameters['std']
 
-            if a == b == mean and std == 0:
+            if a == b:
                 instance.constant_value = a
 
             else:
-                instance.model = scipy.stats.truncnorm(a, b, loc=mean, scale=std)
+                instance.model = scipy.stats.truncnorm(a, b)
 
         return instance
 
@@ -69,8 +65,6 @@ class TruncNorm(ScipyWrapper):
             return {
                 'a': self.constant_value,
                 'b': self.constant_value,
-                'mean': self.constant_value,
-                'std': 0
             }
 
         return dict(

--- a/tests/copulas/multivariate/test_gaussian_copula.py
+++ b/tests/copulas/multivariate/test_gaussian_copula.py
@@ -335,28 +335,24 @@ class TestGaussianCopula(TestCase):
                     'mean': 5.843333333333334,
                     'std': 0.8253012917851409,
                     'fitted': True,
-                    'constant_value': None
                 },
                 'feature_02': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.0540000000000003,
                     'std': 0.4321465800705435,
                     'fitted': True,
-                    'constant_value': None
                 },
                 'feature_03': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.758666666666666,
                     'std': 1.7585291834055212,
                     'fitted': True,
-                    'constant_value': None
                 },
                 'feature_04': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 1.1986666666666668,
                     'std': 0.7606126185881716,
                     'fitted': True,
-                    'constant_value': None
                 }
             }
         }
@@ -387,28 +383,24 @@ class TestGaussianCopula(TestCase):
                     'mean': 5.843333333333334,
                     'std': 0.8253012917851409,
                     'fitted': True,
-                    'constant_value': None
                 },
                 'feature_02': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.0540000000000003,
                     'std': 0.4321465800705435,
                     'fitted': True,
-                    'constant_value': None
                 },
                 'feature_03': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.758666666666666,
                     'std': 1.7585291834055212,
                     'fitted': True,
-                    'constant_value': None
                 },
                 'feature_04': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 1.1986666666666668,
                     'std': 0.7606126185881716,
                     'fitted': True,
-                    'constant_value': None
                 }
             }
         }
@@ -450,28 +442,24 @@ class TestGaussianCopula(TestCase):
                     'mean': 5.843333333333334,
                     'std': 0.8253012917851409,
                     'fitted': True,
-                    'constant_value': None
                 },
                 'feature_02': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.0540000000000003,
                     'std': 0.4321465800705435,
                     'fitted': True,
-                    'constant_value': None
                 },
                 'feature_03': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.758666666666666,
                     'std': 1.7585291834055212,
                     'fitted': True,
-                    'constant_value': None
                 },
                 'feature_04': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 1.1986666666666668,
                     'std': 0.7606126185881716,
                     'fitted': True,
-                    'constant_value': None
                 }
             }
         }
@@ -505,28 +493,24 @@ class TestGaussianCopula(TestCase):
                     'mean': 5.843333333333334,
                     'std': 0.8253012917851409,
                     'fitted': True,
-                    'constant_value': None
                 },
                 'feature_02': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.0540000000000003,
                     'std': 0.4321465800705435,
                     'fitted': True,
-                    'constant_value': None
                 },
                 'feature_03': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 3.758666666666666,
                     'std': 1.7585291834055212,
                     'fitted': True,
-                    'constant_value': None
                 },
                 'feature_04': {
                     'type': 'copulas.univariate.gaussian.GaussianUnivariate',
                     'mean': 1.1986666666666668,
                     'std': 0.7606126185881716,
                     'fitted': True,
-                    'constant_value': None
                 }
             }
         }

--- a/tests/copulas/multivariate/test_gaussian_copula.py
+++ b/tests/copulas/multivariate/test_gaussian_copula.py
@@ -90,14 +90,14 @@ class TestGaussianCopula(TestCase):
     def test_fit_distribution_arg(self):
         """On fit, the distributions for each column use instances of copula.distribution."""
         # Setup
-        distribution = 'copulas.univariate.kde.KDEUnivariate'
+        distribution = 'copulas.univariate.gaussian_kde.GaussianKDE'
         copula = GaussianMultivariate(distribution=distribution)
 
         # Run
         copula.fit(self.data)
 
         # Check
-        assert copula.distribution == 'copulas.univariate.kde.KDEUnivariate'
+        assert copula.distribution == 'copulas.univariate.gaussian_kde.GaussianKDE'
 
         for key in self.data.columns:
             assert key in copula.distribs

--- a/tests/copulas/multivariate/test_vine.py
+++ b/tests/copulas/multivariate/test_vine.py
@@ -118,7 +118,6 @@ class TestVine(TestCase):
                 {
                     'type': 'copulas.univariate.kde.KDEUnivariate',
                     'fitted': False,
-                    'constant_value': None
                 }
             ]
         }

--- a/tests/copulas/univariate/test_gaussian.py
+++ b/tests/copulas/univariate/test_gaussian.py
@@ -18,8 +18,9 @@ class TestGaussianUnivariate(TestCase):
 
         # Check
         assert not copula.name
-        assert copula.mean == 0
-        assert copula.std == 1
+        assert copula.mean is None
+        assert copula.std is None
+        assert copula.constant_value is None
 
     def test___str__(self):
         """str returns details about the model."""
@@ -29,8 +30,8 @@ class TestGaussianUnivariate(TestCase):
         expected_result = '\n'.join([
             'Distribution Type: Gaussian',
             'Variable name: None',
-            'Mean: 0',
-            'Standard deviation: 1'
+            'Mean: None',
+            'Standard deviation: None'
         ])
 
         # Run
@@ -66,8 +67,8 @@ class TestGaussianUnivariate(TestCase):
         instance.fit(column)
 
         # Check
-        assert instance.mean == 0
-        assert instance.std == 1
+        assert instance.mean is None
+        assert instance.std is None
         assert instance.constant_value == 5
 
     def test_get_probability_density(self):
@@ -214,7 +215,6 @@ class TestGaussianUnivariate(TestCase):
             'mean': 2.5,
             'std': 1.707825127659933,
             'fitted': True,
-            'constant_value': None
         }
 
         # Run
@@ -230,7 +230,6 @@ class TestGaussianUnivariate(TestCase):
             'mean': 2.5,
             'std': 1.707825127659933,
             'fitted': True,
-            'constant_value': None
         }
 
         # Run

--- a/tests/copulas/univariate/test_gaussian_kde.py
+++ b/tests/copulas/univariate/test_gaussian_kde.py
@@ -54,14 +54,7 @@ class TestGaussianKDE(TestCase):
         assert instance.constant_value is None
         assert instance.sample == sample_method
         assert instance.probability_density == 'pdf'
-
-        assert kde_mock.call_count == 2
-        expected_call_args = [
-            ((X,), {}),
-            ((X,), {})
-        ]
-        actual_call_args = kde_mock.call_args_list
-        compare_nested_iterables(expected_call_args, actual_call_args)
+        kde_mock.assert_called_once_with(X)
 
     def test_fit_constant(self):
         """If fit data is constant, no gaussian_kde model is created."""
@@ -124,7 +117,6 @@ class TestGaussianKDE(TestCase):
         model_mock.evaluate.return_value = np.array([0.0, 0.5, 1.0])
         model_mock.resample.return_value = fit_data
 
-        
         instance = GaussianKDE()
         instance.fit(fit_data)
         call_data = np.array([-10, 0, 10])
@@ -137,8 +129,7 @@ class TestGaussianKDE(TestCase):
         # Check
         compare_nested_iterables(result, expected_result)
 
-        expected
-        #kde_mock.assert_called_once_with(fit_data)
+        # <kde_mock.assert_called_once_with(fit_data)
         model_mock.evaluate.assert_called_once_with(call_data)
 
     @patch('copulas.univariate.gaussian_kde.scipy.stats.gaussian_kde', autospec=True)
@@ -269,7 +260,7 @@ class TestGaussianKDE(TestCase):
             -0.4694743859349521,
             0.5425600435859647
         ]])
-        
+
         kde_instance_mock = kde_mock.return_value
         kde_instance_mock.dataset = column
         kde_instance_mock.resample.return_value = column
@@ -343,20 +334,8 @@ class TestGaussianKDE(TestCase):
         compare_nested_iterables(result, expected_result)
 
         assert instance.model == model_mock
-
-        expected_kde_call_args = [
-            ((X,), {}),
-            ((expected_result,), {}),
-        ]
-        actual_kde_call_args = kde_mock.call_args_list
-        compare_nested_iterables(actual_kde_call_args, expected_kde_call_args)
-        
-        expected_resample_call_args = [
-            ((5,), {}),
-            ((5,), {}),
-        ]
-        actual_resample_call_args = model_mock.resample.call_args_list
-        compare_nested_iterables(actual_resample_call_args, expected_resample_call_args)
+        kde_mock.assert_called_once_with(X)
+        model_mock.resample.assert_called_once_with(5)
 
     def test_sample_constant(self):
         """If constant_value is set, all the sample have the same value."""

--- a/tests/copulas/univariate/test_gaussian_kde.py
+++ b/tests/copulas/univariate/test_gaussian_kde.py
@@ -205,7 +205,6 @@ class TestGaussianKDE(TestCase):
         # Setup
         parameters = {
             'fitted': True,
-            'constant_value': None,
             'd': 1,
             'n': 10,
             'dataset': [[
@@ -268,7 +267,6 @@ class TestGaussianKDE(TestCase):
         expected_result = {
             'type': 'copulas.univariate.gaussian_kde.GaussianKDE',
             'fitted': True,
-            'constant_value': None,
             'd': 1,
             'n': 10,
             'dataset': [[

--- a/tests/copulas/univariate/test_kde.py
+++ b/tests/copulas/univariate/test_kde.py
@@ -162,7 +162,6 @@ class TestKDEUnivariate(TestCase):
         # Setup
         parameters = {
             'fitted': True,
-            'constant_value': None,
             'd': 1,
             'n': 10,
             'dataset': [[
@@ -225,7 +224,6 @@ class TestKDEUnivariate(TestCase):
         expected_result = {
             'type': 'copulas.univariate.kde.KDEUnivariate',
             'fitted': True,
-            'constant_value': None,
             'd': 1,
             'n': 10,
             'dataset': [[

--- a/tests/copulas/univariate/test_kde.py
+++ b/tests/copulas/univariate/test_kde.py
@@ -41,7 +41,6 @@ class TestKDEUnivariate(TestCase):
         X = np.array([1, 2, 3, 4, 5])
 
         kde_instance_mock = kde_mock.return_value
-        kde_instance_mock.resample.return_value = 'resampled_values'
 
         # Run
         instance.fit(X)
@@ -50,12 +49,7 @@ class TestKDEUnivariate(TestCase):
         assert instance.model == kde_instance_mock
         assert instance.fitted is True
         assert instance.constant_value is None
-
-        assert kde_mock.call_count == 2
-        kde_mock.assert_any_call(X)
-        kde_mock.assert_any_call('resampled_values')
-
-        kde_instance_mock.resample.assert_called_once_with(10)
+        kde_mock.assert_called_once_with(X)
 
     def test_fit_constant(self):
         """If fit data is constant, no gaussian_kde model is created."""
@@ -143,21 +137,8 @@ class TestKDEUnivariate(TestCase):
         compare_nested_iterables(result, expected_result)
 
         assert instance.model == model_mock
-
-        expected_kde_calls = [
-            ((X,), {}),
-            ((expected_result,), {})
-        ]
-        actual_kde_calls = kde_mock.call_args_list
-        compare_nested_iterables(expected_kde_calls, actual_kde_calls)
-
-        expected_resample_calls = [
-            ((10,), {}),
-            ((5,), {})
-        ]
-        actual_resample_calls = model_mock.resample.call_args_list
-
-        compare_nested_iterables(expected_resample_calls, actual_resample_calls)
+        kde_mock.assert_called_once_with(X)
+        model_mock.resample.assert_called_once_with(5)
 
     def test_sample_constant(self):
         """If constant_value is set, all the sample have the same value."""
@@ -256,16 +237,16 @@ class TestKDEUnivariate(TestCase):
             'type': 'copulas.univariate.kde.KDEUnivariate',
             'fitted': True,
             'dataset': [[
-                -0.05203280917218478,
-                -0.17423174119062362,
-                0.3221364588838637,
-                0.4838795829614052,
-                0.08850966508764879,
-                -0.9021663526973743,
-                0.6449521391849532,
-                1.1253616092767915,
-                2.347399441357645,
-                1.3698755884178568
+                0.4967141530112327,
+                -0.13826430117118466,
+                0.6476885381006925,
+                1.5230298564080254,
+                -0.23415337472333597,
+                -0.23413695694918055,
+                1.5792128155073915,
+                0.7674347291529088,
+                -0.4694743859349521,
+                0.5425600435859647
             ]],
         }
 

--- a/tests/copulas/univariate/test_kde.py
+++ b/tests/copulas/univariate/test_kde.py
@@ -165,7 +165,7 @@ class TestKDEUnivariate(TestCase):
         instance.fit(X)
 
         expected_result_random_state = np.array([
-            [3.1443663, 4.33023998, 4.35733536, 6.44897849, 5.09086686]
+            [5.02156389, 5.45857107, 6.12161148, 4.56801267, 6.14017901]
         ])
 
         # Run

--- a/tests/copulas/univariate/test_truncnorm.py
+++ b/tests/copulas/univariate/test_truncnorm.py
@@ -50,8 +50,7 @@ class TestTruncNorm(TestCase):
         assert instance.cumulative_distribution == 'cumulative_distribution'
         assert instance.sample == 'sample'
 
-        truncnorm_mock.assert_called_once_with(
-            1 - EPSILON, 5 + EPSILON, loc=3.0, scale=1.4142135623730951)
+        truncnorm_mock.assert_called_once_with(1 - EPSILON, 5 + EPSILON)
 
     def test_from_dict_unfitted(self):
         """from_dict creates a new instance from a dict of params."""
@@ -77,8 +76,6 @@ class TestTruncNorm(TestCase):
             'fitted': True,
             'a': -10,
             'b': 10,
-            'mean': 0,
-            'std': 1
         }
 
         # Run
@@ -89,8 +86,6 @@ class TestTruncNorm(TestCase):
         assert instance.constant_value is None
         assert instance.model.a == -10
         assert instance.model.b == 10
-        assert instance.model.kwds['loc'] == 0
-        assert instance.model.kwds['scale'] == 1
 
     def test__fit_params(self):
         """_fit_params returns a dict with the params of the scipy model."""
@@ -102,8 +97,6 @@ class TestTruncNorm(TestCase):
         expected_result = {
             'a': - EPSILON,
             'b': 4 + EPSILON,
-            'loc': 2.0,
-            'scale': 1.4142135623730951
         }
 
         # Run

--- a/tests/copulas/univariate/test_truncnorm.py
+++ b/tests/copulas/univariate/test_truncnorm.py
@@ -50,7 +50,8 @@ class TestTruncNorm(TestCase):
         assert instance.cumulative_distribution == 'cumulative_distribution'
         assert instance.sample == 'sample'
 
-        truncnorm_mock.assert_called_once_with(1 - EPSILON, 5 + EPSILON)
+        truncnorm_mock.assert_called_once_with(
+            1 - EPSILON, 5 + EPSILON, loc=3.0, scale=1.4142135623730951)
 
     def test_from_dict_unfitted(self):
         """from_dict creates a new instance from a dict of params."""
@@ -74,8 +75,10 @@ class TestTruncNorm(TestCase):
         parameters = {
             'type': 'copulas.univariate.truncnorm.TruncNorm',
             'fitted': True,
-            'a': 0,
-            'b': 10
+            'a': -10,
+            'b': 10,
+            'mean': 0,
+            'std': 1
         }
 
         # Run
@@ -84,8 +87,10 @@ class TestTruncNorm(TestCase):
         # Check
         assert instance.fitted is True
         assert instance.constant_value is None
-        assert instance.model.a == 0
+        assert instance.model.a == -10
         assert instance.model.b == 10
+        assert instance.model.kwds['loc'] == 0
+        assert instance.model.kwds['scale'] == 1
 
     def test__fit_params(self):
         """_fit_params returns a dict with the params of the scipy model."""
@@ -96,7 +101,9 @@ class TestTruncNorm(TestCase):
 
         expected_result = {
             'a': - EPSILON,
-            'b': 4 + EPSILON
+            'b': 4 + EPSILON,
+            'loc': 2.0,
+            'scale': 1.4142135623730951
         }
 
         # Run

--- a/tests/copulas/univariate/test_truncnorm.py
+++ b/tests/copulas/univariate/test_truncnorm.py
@@ -58,7 +58,6 @@ class TestTruncNorm(TestCase):
         parameters = {
             'type': 'copulas.univariate.truncnorm.TruncNorm',
             'fitted': False,
-            'constant_value': None
         }
 
         # Run
@@ -75,7 +74,6 @@ class TestTruncNorm(TestCase):
         parameters = {
             'type': 'copulas.univariate.truncnorm.TruncNorm',
             'fitted': True,
-            'constant_value': None,
             'a': 0,
             'b': 10
         }


### PR DESCRIPTION
Resolves #99 

Removed the key `constant_value` on the serialization of univariate distributions.