### PR TITLE
Added support to python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # Config file for automatic testing at travis-ci.org
+dist: xenial
 language: python
 python:
+  - 3.7
   - 3.6
   - 3.5
 
@@ -22,4 +24,4 @@ deploy:
     target-branch: gh-pages
     on:
       branch: stable
-      python: 3.6
+      python: 3.7

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     description="A python library for building different types of copulas and using them for sampling.",
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist = py35, py36, lint, docs
 
 [travis]
 python =
-    3.6: py36, lint, docs
+    3.7: py37, lint, docs
+    3.6: py36
     3.5: py35
 
 


### PR DESCRIPTION
Resolves #53 

Updated tox.ini, setup.py and .travis.yml to support python3.7

If we don't support python versions higher that python 3.7, we must change `python_requires='>=3.5,` to `python_requires='>=3.5, <3.8`?